### PR TITLE
Cleans up nlohmann::json.find(...) calls

### DIFF
--- a/src/WallpaperEngine/Core/CObject.cpp
+++ b/src/WallpaperEngine/Core/CObject.cpp
@@ -5,8 +5,6 @@
 #include "WallpaperEngine/Core/Objects/CSound.h"
 #include "WallpaperEngine/Core/Objects/CParticle.h"
 
-#include "Core.h"
-
 using namespace WallpaperEngine::Core;
 
 CObject::CObject (
@@ -29,12 +27,12 @@ CObject::CObject (
 
 CObject* CObject::fromJSON (json data)
 {
-    auto id_it = jsonFindRequired (&data, "id", "Objects must have id");
+    auto id_it = jsonFindRequired (data, "id", "Objects must have id");
     auto visible_it = data.find ("visible");
-    auto origin_it = jsonFindRequired (&data, "origin", "Objects must have origin point");
-    auto scale_it = jsonFindRequired (&data, "scale", "Objects must have scale");
-    auto angles_it = jsonFindRequired (&data, "angles", "Objects must have angles");
-    auto name_it = jsonFindRequired (&data, "name", "Objects must have name");
+    auto origin_it = jsonFindRequired (data, "origin", "Objects must have origin point");
+    auto scale_it = jsonFindRequired (data, "scale", "Objects must have scale");
+    auto angles_it = jsonFindRequired (data, "angles", "Objects must have angles");
+    auto name_it = jsonFindRequired (data, "name", "Objects must have name");
     auto effects_it = data.find ("effects");
     auto dependencies_it = data.find ("dependencies");
 

--- a/src/WallpaperEngine/Core/CObject.cpp
+++ b/src/WallpaperEngine/Core/CObject.cpp
@@ -29,12 +29,12 @@ CObject::CObject (
 
 CObject* CObject::fromJSON (json data)
 {
-    auto id_it = jsonFindValueRequired(&data, "id", "Objects must have id");
+    auto id_it = jsonFindRequired (&data, "id", "Objects must have id");
     auto visible_it = data.find ("visible");
-    auto origin_it = jsonFindValueRequired(&data, "origin", "Objects must have origin point");
-    auto scale_it = jsonFindValueRequired(&data, "scale", "Objects must have scale");
-    auto angles_it = jsonFindValueRequired(&data, "angles", "Objects must have angles");
-    auto name_it = jsonFindValueRequired(&data, "name", "Objects must have name");
+    auto origin_it = jsonFindRequired (&data, "origin", "Objects must have origin point");
+    auto scale_it = jsonFindRequired (&data, "scale", "Objects must have scale");
+    auto angles_it = jsonFindRequired (&data, "angles", "Objects must have angles");
+    auto name_it = jsonFindRequired (&data, "name", "Objects must have name");
     auto effects_it = data.find ("effects");
     auto dependencies_it = data.find ("dependencies");
 

--- a/src/WallpaperEngine/Core/CObject.cpp
+++ b/src/WallpaperEngine/Core/CObject.cpp
@@ -29,41 +29,16 @@ CObject::CObject (
 
 CObject* CObject::fromJSON (json data)
 {
-    auto id_it = data.find ("id");
+    auto id_it = jsonFindValueRequired(&data, "id", "Objects must have id");
     auto visible_it = data.find ("visible");
-    auto origin_it = data.find ("origin");
-    auto scale_it = data.find ("scale");
-    auto angles_it = data.find ("angles");
-    auto name_it = data.find ("name");
+    auto origin_it = jsonFindValueRequired(&data, "origin", "Objects must have origin point");
+    auto scale_it = jsonFindValueRequired(&data, "scale", "Objects must have scale");
+    auto angles_it = jsonFindValueRequired(&data, "angles", "Objects must have angles");
+    auto name_it = jsonFindValueRequired(&data, "name", "Objects must have name");
     auto effects_it = data.find ("effects");
     auto dependencies_it = data.find ("dependencies");
 
     bool visible = true;
-
-    if (id_it == data.end ())
-    {
-        throw std::runtime_error ("Objects must have id");
-    }
-
-    if (origin_it == data.end ())
-    {
-        throw std::runtime_error ("Objects must have origin point");
-    }
-
-    if (scale_it == data.end ())
-    {
-        throw std::runtime_error ("Objects must have scale");
-    }
-
-    if (angles_it == data.end ())
-    {
-        throw std::runtime_error ("Objects must have angles");
-    }
-
-    if (name_it == data.end ())
-    {
-        throw std::runtime_error ("Objects must have name");
-    }
 
     // visibility is optional
     if (visible_it != data.end ())

--- a/src/WallpaperEngine/Core/CObject.h
+++ b/src/WallpaperEngine/Core/CObject.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
+
+#include "Core.h"
 
 #include "WallpaperEngine/Core/Objects/CEffect.h"
 

--- a/src/WallpaperEngine/Core/CProject.cpp
+++ b/src/WallpaperEngine/Core/CProject.cpp
@@ -2,6 +2,8 @@
 
 #include "CProject.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 using namespace WallpaperEngine::Core;
 
 CProject::CProject (std::string title, std::string type, CScene *scene) :
@@ -16,25 +18,10 @@ CProject* CProject::fromFile (const irr::io::path& filename)
 {
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
 
-    auto title = content.find ("title");
-    auto type = content.find ("type");
-    auto file = content.find ("file");
+    auto title = jsonFindValueRequired (&content, "title", "Project title missing");
+    auto type = jsonFindValueRequired (&content, "title", "Project type missing");
+    auto file = jsonFindValueRequired (&content, "title", "Project's main file missing");
     auto general = content.find ("general");
-
-    if (title == content.end ())
-    {
-        throw std::runtime_error ("Project title missing");
-    }
-
-    if (type == content.end ())
-    {
-        throw std::runtime_error ("Project type missing");
-    }
-
-    if (file == content.end ())
-    {
-        throw std::runtime_error ("Project's main file missing");
-    }
 
     CProject* project = new CProject (
         *title,

--- a/src/WallpaperEngine/Core/CProject.cpp
+++ b/src/WallpaperEngine/Core/CProject.cpp
@@ -2,8 +2,6 @@
 
 #include "CProject.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core;
 
 CProject::CProject (std::string title, std::string type, CScene *scene) :
@@ -18,9 +16,9 @@ CProject* CProject::fromFile (const irr::io::path& filename)
 {
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
 
-    auto title = jsonFindRequired (&content, "title", "Project title missing");
-    auto type = jsonFindRequired (&content, "type", "Project type missing");
-    auto file = jsonFindRequired (&content, "file", "Project's main file missing");
+    auto title = jsonFindRequired (content, "title", "Project title missing");
+    auto type = jsonFindRequired (content, "type", "Project type missing");
+    auto file = jsonFindRequired (content, "file", "Project's main file missing");
     auto general = content.find ("general");
 
     CProject* project = new CProject (

--- a/src/WallpaperEngine/Core/CProject.cpp
+++ b/src/WallpaperEngine/Core/CProject.cpp
@@ -19,8 +19,8 @@ CProject* CProject::fromFile (const irr::io::path& filename)
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
 
     auto title = jsonFindRequired (&content, "title", "Project title missing");
-    auto type = jsonFindRequired (&content, "title", "Project type missing");
-    auto file = jsonFindRequired (&content, "title", "Project's main file missing");
+    auto type = jsonFindRequired (&content, "type", "Project type missing");
+    auto file = jsonFindRequired (&content, "file", "Project's main file missing");
     auto general = content.find ("general");
 
     CProject* project = new CProject (

--- a/src/WallpaperEngine/Core/CProject.cpp
+++ b/src/WallpaperEngine/Core/CProject.cpp
@@ -18,9 +18,9 @@ CProject* CProject::fromFile (const irr::io::path& filename)
 {
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
 
-    auto title = jsonFindValueRequired (&content, "title", "Project title missing");
-    auto type = jsonFindValueRequired (&content, "title", "Project type missing");
-    auto file = jsonFindValueRequired (&content, "title", "Project's main file missing");
+    auto title = jsonFindRequired (&content, "title", "Project title missing");
+    auto type = jsonFindRequired (&content, "title", "Project type missing");
+    auto file = jsonFindRequired (&content, "title", "Project's main file missing");
     auto general = content.find ("general");
 
     CProject* project = new CProject (

--- a/src/WallpaperEngine/Core/CProject.h
+++ b/src/WallpaperEngine/Core/CProject.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <irrlicht/irrlicht.h>
-#include <nlohmann/json.hpp>
 
 #include "CScene.h"
+#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/Projects/CProperty.h"
 
 namespace WallpaperEngine::Core

--- a/src/WallpaperEngine/Core/CScene.cpp
+++ b/src/WallpaperEngine/Core/CScene.cpp
@@ -50,127 +50,27 @@ CScene* CScene::fromFile (const irr::io::path& filename)
 {
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
 
-    auto camera_it = content.find ("camera");
-    auto general_it = content.find ("general");
-    auto objects_it = content.find ("objects");
+    auto camera_it = jsonFindValueRequired(&content, "camera", "Scenes must have a defined camera");
+    auto general_it = jsonFindValueRequired(&content, "general", "Scenes must have a general section");
+    auto objects_it = jsonFindValueRequired(&content, "objects", "Scenes must have a list of objects to display");
 
-    if (camera_it == content.end ())
-    {
-        throw std::runtime_error ("Scenes must have a defined camera");
-    }
-
-    if (general_it == content.end ())
-    {
-        throw std::runtime_error ("Scenes must have a general section");
-    }
-
-    if (objects_it == content.end ())
-    {
-        throw std::runtime_error ("Scenes must have a list of objects to display");
-    }
-
-    auto ambientcolor_it = (*general_it).find ("ambientcolor");
-    auto bloom_it = (*general_it).find ("bloom");
-    auto bloomstrength_it = (*general_it).find ("bloomstrength");
-    auto bloomthreshold_it = (*general_it).find ("bloomthreshold");
-    auto camerafade_it = (*general_it).find ("camerafade");
-    auto cameraparallax_it = (*general_it).find ("cameraparallax");
-    auto cameraparallaxamount_it = (*general_it).find ("cameraparallaxamount");
-    auto cameraparallaxdelay_it = (*general_it).find ("cameraparallaxdelay");
-    auto cameraparallaxmouseinfluence_it = (*general_it).find ("cameraparallaxmouseinfluence");
-    auto camerapreview_it = (*general_it).find ("camerapreview");
-    auto camerashake_it = (*general_it).find ("camerashake");
-    auto camerashakeamplitude_it = (*general_it).find ("camerashakeamplitude");
-    auto camerashakeroughness_it = (*general_it).find ("camerashakeroughness");
-    auto camerashakespeed_it = (*general_it).find ("camerashakespeed");
-    auto clearcolor_it = (*general_it).find ("clearcolor");
-    auto orthogonalprojection_it = (*general_it).find ("orthogonalprojection");
-    auto skylightcolor_it = (*general_it).find ("skylightcolor");
-
-    if (ambientcolor_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have ambient color");
-    }
-
-    if (bloom_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have bloom flag");
-    }
-
-    if (bloomstrength_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have bloom strength");
-    }
-
-    if (bloomthreshold_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have bloom threshold");
-    }
-
-    if (camerafade_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera fade");
-    }
-
-    if (cameraparallax_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera parallax");
-    }
-
-    if (cameraparallaxamount_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera parallax amount");
-    }
-
-    if (cameraparallaxdelay_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera parallax delay");
-    }
-
-    if (cameraparallaxmouseinfluence_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera parallax mouse influence");
-    }
-
-    if (camerapreview_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera preview");
-    }
-
-    if (camerashake_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera shake");
-    }
-
-    if (camerashakeamplitude_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera shake amplitude");
-    }
-
-    if (camerashakeroughness_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera shake roughness");
-    }
-
-    if (camerashakespeed_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have camera shake speed");
-    }
-
-    if (clearcolor_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have clear color");
-    }
-
-    if (orthogonalprojection_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have orthogonal projection info");
-    }
-
-    if (skylightcolor_it == (*general_it).end ())
-    {
-        throw std::runtime_error ("General section must have skylight color");
-    }
+    auto ambientcolor_it = jsonFindValueRequired(&(*general_it), "ambientcolor", "General section must have ambient color");
+    auto bloom_it = jsonFindValueRequired(&(*general_it), "bloom", "General section must have bloom flag");
+    auto bloomstrength_it = jsonFindValueRequired(&(*general_it), "bloomstrength", "General section must have bloom strength");
+    auto bloomthreshold_it = jsonFindValueRequired(&(*general_it), "bloomthreshold", "General section must have bloom threshold");
+    auto camerafade_it = jsonFindValueRequired(&(*general_it), "camerafade", "General section must have camera fade");
+    auto cameraparallax_it = jsonFindValueRequired(&(*general_it), "cameraparallax", "General section must have camera parallax");
+    auto cameraparallaxamount_it = jsonFindValueRequired(&(*general_it), "cameraparallaxamount", "General section must have camera parallax amount");
+    auto cameraparallaxdelay_it = jsonFindValueRequired(&(*general_it), "cameraparallaxdelay", "General section must have camera parallax delay");
+    auto cameraparallaxmouseinfluence_it = jsonFindValueRequired(&(*general_it), "cameraparallaxmouseinfluence", "General section must have camera parallax mouse influence");
+    auto camerapreview_it = jsonFindValueRequired(&(*general_it), "camerapreview", "General section must have camera preview");
+    auto camerashake_it = jsonFindValueRequired(&(*general_it), "camerashake", "General section must have camera shake");
+    auto camerashakeamplitude_it = jsonFindValueRequired(&(*general_it), "camerashakeamplitude", "General section must have camera shake amplitude");
+    auto camerashakeroughness_it = jsonFindValueRequired(&(*general_it), "camerashakeroughness", "General section must have camera shake roughness");
+    auto camerashakespeed_it = jsonFindValueRequired(&(*general_it), "camerashakespeed", "General section must have camera shake speed");
+    auto clearcolor_it = jsonFindValueRequired(&(*general_it), "clearcolor", "General section must have clear color");
+    auto orthogonalprojection_it = jsonFindValueRequired(&(*general_it), "orthogonalprojection", "General section must have orthogonal projection info");
+    auto skylightcolor_it = jsonFindValueRequired(&(*general_it), "skylightcolor", "General section must have skylight color");
 
     CScene* scene = new CScene (
             Scenes::CCamera::fromJSON (*camera_it),

--- a/src/WallpaperEngine/Core/CScene.cpp
+++ b/src/WallpaperEngine/Core/CScene.cpp
@@ -1,7 +1,6 @@
 #include "CScene.h"
 #include "CProject.h"
 
-#include "Core.h"
 #include "WallpaperEngine/FileSystem/FileSystem.h"
 
 using namespace WallpaperEngine::Core;
@@ -50,27 +49,27 @@ CScene* CScene::fromFile (const irr::io::path& filename)
 {
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
 
-    auto camera_it = jsonFindRequired (&content, "camera", "Scenes must have a defined camera");
-    auto general_it = jsonFindRequired (&content, "general", "Scenes must have a general section");
-    auto objects_it = jsonFindRequired (&content, "objects", "Scenes must have a list of objects to display");
+    auto camera_it = jsonFindRequired (content, "camera", "Scenes must have a defined camera");
+    auto general_it = jsonFindRequired (content, "general", "Scenes must have a general section");
+    auto objects_it = jsonFindRequired (content, "objects", "Scenes must have a list of objects to display");
 
-    auto ambientcolor_it = jsonFindRequired (&(*general_it), "ambientcolor", "General section must have ambient color");
-    auto bloom_it = jsonFindRequired (&(*general_it), "bloom", "General section must have bloom flag");
-    auto bloomstrength_it = jsonFindRequired (&(*general_it), "bloomstrength", "General section must have bloom strength");
-    auto bloomthreshold_it = jsonFindRequired (&(*general_it), "bloomthreshold", "General section must have bloom threshold");
-    auto camerafade_it = jsonFindRequired (&(*general_it), "camerafade", "General section must have camera fade");
-    auto cameraparallax_it = jsonFindRequired (&(*general_it), "cameraparallax", "General section must have camera parallax");
-    auto cameraparallaxamount_it = jsonFindRequired (&(*general_it), "cameraparallaxamount", "General section must have camera parallax amount");
-    auto cameraparallaxdelay_it = jsonFindRequired (&(*general_it), "cameraparallaxdelay", "General section must have camera parallax delay");
-    auto cameraparallaxmouseinfluence_it = jsonFindRequired (&(*general_it), "cameraparallaxmouseinfluence", "General section must have camera parallax mouse influence");
-    auto camerapreview_it = jsonFindRequired (&(*general_it), "camerapreview", "General section must have camera preview");
-    auto camerashake_it = jsonFindRequired (&(*general_it), "camerashake", "General section must have camera shake");
-    auto camerashakeamplitude_it = jsonFindRequired (&(*general_it), "camerashakeamplitude", "General section must have camera shake amplitude");
-    auto camerashakeroughness_it = jsonFindRequired (&(*general_it), "camerashakeroughness", "General section must have camera shake roughness");
-    auto camerashakespeed_it = jsonFindRequired (&(*general_it), "camerashakespeed", "General section must have camera shake speed");
-    auto clearcolor_it = jsonFindRequired (&(*general_it), "clearcolor", "General section must have clear color");
-    auto orthogonalprojection_it = jsonFindRequired (&(*general_it), "orthogonalprojection", "General section must have orthogonal projection info");
-    auto skylightcolor_it = jsonFindRequired (&(*general_it), "skylightcolor", "General section must have skylight color");
+    auto ambientcolor_it = jsonFindRequired (*general_it, "ambientcolor", "General section must have ambient color");
+    auto bloom_it = jsonFindRequired (*general_it, "bloom", "General section must have bloom flag");
+    auto bloomstrength_it = jsonFindRequired (*general_it, "bloomstrength", "General section must have bloom strength");
+    auto bloomthreshold_it = jsonFindRequired (*general_it, "bloomthreshold", "General section must have bloom threshold");
+    auto camerafade_it = jsonFindRequired (*general_it, "camerafade", "General section must have camera fade");
+    auto cameraparallax_it = jsonFindRequired (*general_it, "cameraparallax", "General section must have camera parallax");
+    auto cameraparallaxamount_it = jsonFindRequired (*general_it, "cameraparallaxamount", "General section must have camera parallax amount");
+    auto cameraparallaxdelay_it = jsonFindRequired (*general_it, "cameraparallaxdelay", "General section must have camera parallax delay");
+    auto cameraparallaxmouseinfluence_it = jsonFindRequired (*general_it, "cameraparallaxmouseinfluence", "General section must have camera parallax mouse influence");
+    auto camerapreview_it = jsonFindRequired (*general_it, "camerapreview", "General section must have camera preview");
+    auto camerashake_it = jsonFindRequired (*general_it, "camerashake", "General section must have camera shake");
+    auto camerashakeamplitude_it = jsonFindRequired (*general_it, "camerashakeamplitude", "General section must have camera shake amplitude");
+    auto camerashakeroughness_it = jsonFindRequired (*general_it, "camerashakeroughness", "General section must have camera shake roughness");
+    auto camerashakespeed_it = jsonFindRequired (*general_it, "camerashakespeed", "General section must have camera shake speed");
+    auto clearcolor_it = jsonFindRequired (*general_it, "clearcolor", "General section must have clear color");
+    auto orthogonalprojection_it = jsonFindRequired (*general_it, "orthogonalprojection", "General section must have orthogonal projection info");
+    auto skylightcolor_it = jsonFindRequired (*general_it, "skylightcolor", "General section must have skylight color");
 
     CScene* scene = new CScene (
             Scenes::CCamera::fromJSON (*camera_it),

--- a/src/WallpaperEngine/Core/CScene.cpp
+++ b/src/WallpaperEngine/Core/CScene.cpp
@@ -50,27 +50,27 @@ CScene* CScene::fromFile (const irr::io::path& filename)
 {
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
 
-    auto camera_it = jsonFindValueRequired(&content, "camera", "Scenes must have a defined camera");
-    auto general_it = jsonFindValueRequired(&content, "general", "Scenes must have a general section");
-    auto objects_it = jsonFindValueRequired(&content, "objects", "Scenes must have a list of objects to display");
+    auto camera_it = jsonFindRequired (&content, "camera", "Scenes must have a defined camera");
+    auto general_it = jsonFindRequired (&content, "general", "Scenes must have a general section");
+    auto objects_it = jsonFindRequired (&content, "objects", "Scenes must have a list of objects to display");
 
-    auto ambientcolor_it = jsonFindValueRequired(&(*general_it), "ambientcolor", "General section must have ambient color");
-    auto bloom_it = jsonFindValueRequired(&(*general_it), "bloom", "General section must have bloom flag");
-    auto bloomstrength_it = jsonFindValueRequired(&(*general_it), "bloomstrength", "General section must have bloom strength");
-    auto bloomthreshold_it = jsonFindValueRequired(&(*general_it), "bloomthreshold", "General section must have bloom threshold");
-    auto camerafade_it = jsonFindValueRequired(&(*general_it), "camerafade", "General section must have camera fade");
-    auto cameraparallax_it = jsonFindValueRequired(&(*general_it), "cameraparallax", "General section must have camera parallax");
-    auto cameraparallaxamount_it = jsonFindValueRequired(&(*general_it), "cameraparallaxamount", "General section must have camera parallax amount");
-    auto cameraparallaxdelay_it = jsonFindValueRequired(&(*general_it), "cameraparallaxdelay", "General section must have camera parallax delay");
-    auto cameraparallaxmouseinfluence_it = jsonFindValueRequired(&(*general_it), "cameraparallaxmouseinfluence", "General section must have camera parallax mouse influence");
-    auto camerapreview_it = jsonFindValueRequired(&(*general_it), "camerapreview", "General section must have camera preview");
-    auto camerashake_it = jsonFindValueRequired(&(*general_it), "camerashake", "General section must have camera shake");
-    auto camerashakeamplitude_it = jsonFindValueRequired(&(*general_it), "camerashakeamplitude", "General section must have camera shake amplitude");
-    auto camerashakeroughness_it = jsonFindValueRequired(&(*general_it), "camerashakeroughness", "General section must have camera shake roughness");
-    auto camerashakespeed_it = jsonFindValueRequired(&(*general_it), "camerashakespeed", "General section must have camera shake speed");
-    auto clearcolor_it = jsonFindValueRequired(&(*general_it), "clearcolor", "General section must have clear color");
-    auto orthogonalprojection_it = jsonFindValueRequired(&(*general_it), "orthogonalprojection", "General section must have orthogonal projection info");
-    auto skylightcolor_it = jsonFindValueRequired(&(*general_it), "skylightcolor", "General section must have skylight color");
+    auto ambientcolor_it = jsonFindRequired (&(*general_it), "ambientcolor", "General section must have ambient color");
+    auto bloom_it = jsonFindRequired (&(*general_it), "bloom", "General section must have bloom flag");
+    auto bloomstrength_it = jsonFindRequired (&(*general_it), "bloomstrength", "General section must have bloom strength");
+    auto bloomthreshold_it = jsonFindRequired (&(*general_it), "bloomthreshold", "General section must have bloom threshold");
+    auto camerafade_it = jsonFindRequired (&(*general_it), "camerafade", "General section must have camera fade");
+    auto cameraparallax_it = jsonFindRequired (&(*general_it), "cameraparallax", "General section must have camera parallax");
+    auto cameraparallaxamount_it = jsonFindRequired (&(*general_it), "cameraparallaxamount", "General section must have camera parallax amount");
+    auto cameraparallaxdelay_it = jsonFindRequired (&(*general_it), "cameraparallaxdelay", "General section must have camera parallax delay");
+    auto cameraparallaxmouseinfluence_it = jsonFindRequired (&(*general_it), "cameraparallaxmouseinfluence", "General section must have camera parallax mouse influence");
+    auto camerapreview_it = jsonFindRequired (&(*general_it), "camerapreview", "General section must have camera preview");
+    auto camerashake_it = jsonFindRequired (&(*general_it), "camerashake", "General section must have camera shake");
+    auto camerashakeamplitude_it = jsonFindRequired (&(*general_it), "camerashakeamplitude", "General section must have camera shake amplitude");
+    auto camerashakeroughness_it = jsonFindRequired (&(*general_it), "camerashakeroughness", "General section must have camera shake roughness");
+    auto camerashakespeed_it = jsonFindRequired (&(*general_it), "camerashakespeed", "General section must have camera shake speed");
+    auto clearcolor_it = jsonFindRequired (&(*general_it), "clearcolor", "General section must have clear color");
+    auto orthogonalprojection_it = jsonFindRequired (&(*general_it), "orthogonalprojection", "General section must have orthogonal projection info");
+    auto skylightcolor_it = jsonFindRequired (&(*general_it), "skylightcolor", "General section must have skylight color");
 
     CScene* scene = new CScene (
             Scenes::CCamera::fromJSON (*camera_it),

--- a/src/WallpaperEngine/Core/CScene.h
+++ b/src/WallpaperEngine/Core/CScene.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <irrlicht/irrlicht.h>
-#include <nlohmann/json.hpp>
 
 #include "CProject.h"
 #include "CObject.h"
+
+#include "Core.h"
 
 #include "WallpaperEngine/Core/Scenes/CCamera.h"
 #include "WallpaperEngine/Core/Scenes/CProjection.h"

--- a/src/WallpaperEngine/Core/Core.cpp
+++ b/src/WallpaperEngine/Core/Core.cpp
@@ -60,10 +60,10 @@ irr::video::SColor Core::atoSColor (const std::string& str)
     return Core::atoSColor (str.c_str ());
 }
 
-nlohmann::detail::iter_impl<nlohmann::json> Core::jsonFindRequired (nlohmann::json *data, const char *key, const char *notFoundMsg)
+nlohmann::detail::iter_impl<nlohmann::json> Core::jsonFindRequired (nlohmann::json& data, const char *key, const char *notFoundMsg)
 {
-    auto value = data->find (key);
-    if (value == data->end ())
+    auto value = data.find (key);
+    if (value == data.end ())
     {
         throw std::runtime_error (notFoundMsg);
     }

--- a/src/WallpaperEngine/Core/Core.cpp
+++ b/src/WallpaperEngine/Core/Core.cpp
@@ -60,7 +60,7 @@ irr::video::SColor Core::atoSColor (const std::string& str)
     return Core::atoSColor (str.c_str ());
 }
 
-nlohmann::detail::iter_impl<nlohmann::json> jsonFindValueRequired (nlohmann::json *data, const char *key, const char *notFoundMsg)
+nlohmann::detail::iter_impl<nlohmann::json> jsonFindRequired (nlohmann::json *data, const char *key, const char *notFoundMsg)
 {
     auto value = data->find (key);
     if (value == data->end ())

--- a/src/WallpaperEngine/Core/Core.cpp
+++ b/src/WallpaperEngine/Core/Core.cpp
@@ -59,3 +59,13 @@ irr::video::SColor Core::atoSColor (const std::string& str)
 {
     return Core::atoSColor (str.c_str ());
 }
+
+nlohmann::detail::iter_impl<nlohmann::json> jsonFindValueRequired (nlohmann::json *data, const char *key, const char *notFoundMsg)
+{
+    auto value = data->find (key);
+    if (value == data->end ())
+    {
+        throw std::runtime_error (notFoundMsg);
+    }
+    return value;
+}

--- a/src/WallpaperEngine/Core/Core.cpp
+++ b/src/WallpaperEngine/Core/Core.cpp
@@ -60,7 +60,7 @@ irr::video::SColor Core::atoSColor (const std::string& str)
     return Core::atoSColor (str.c_str ());
 }
 
-nlohmann::detail::iter_impl<nlohmann::json> jsonFindRequired (nlohmann::json *data, const char *key, const char *notFoundMsg)
+nlohmann::detail::iter_impl<nlohmann::json> Core::jsonFindRequired (nlohmann::json *data, const char *key, const char *notFoundMsg)
 {
     auto value = data->find (key);
     if (value == data->end ())

--- a/src/WallpaperEngine/Core/Core.h
+++ b/src/WallpaperEngine/Core/Core.h
@@ -18,5 +18,5 @@ namespace WallpaperEngine::Core
     irr::video::SColor atoSColor (const char *str);
     irr::video::SColor atoSColor (const std::string& str);
 
-    nlohmann::detail::iter_impl<nlohmann::json> jsonFindRequired (nlohmann::json *data, const char *key, const char *notFoundMsg);
+    nlohmann::json::iterator jsonFindRequired (nlohmann::json& data, const char *key, const char *notFoundMsg);
 };

--- a/src/WallpaperEngine/Core/Core.h
+++ b/src/WallpaperEngine/Core/Core.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <irrlicht/irrlicht.h>
+#include <nlohmann/json.hpp>
 
 namespace WallpaperEngine::Core
 {
@@ -16,4 +17,6 @@ namespace WallpaperEngine::Core
 
     irr::video::SColor atoSColor (const char *str);
     irr::video::SColor atoSColor (const std::string& str);
+
+    nlohmann::detail::iter_impl<nlohmann::json> jsonFindValueRequired (nlohmann::json *data, const char *key, const char *notFoundMsg);
 };

--- a/src/WallpaperEngine/Core/Core.h
+++ b/src/WallpaperEngine/Core/Core.h
@@ -18,5 +18,5 @@ namespace WallpaperEngine::Core
     irr::video::SColor atoSColor (const char *str);
     irr::video::SColor atoSColor (const std::string& str);
 
-    nlohmann::detail::iter_impl<nlohmann::json> jsonFindValueRequired (nlohmann::json *data, const char *key, const char *notFoundMsg);
+    nlohmann::detail::iter_impl<nlohmann::json> jsonFindRequired (nlohmann::json *data, const char *key, const char *notFoundMsg);
 };

--- a/src/WallpaperEngine/Core/Objects/CEffect.cpp
+++ b/src/WallpaperEngine/Core/Objects/CEffect.cpp
@@ -2,7 +2,6 @@
 
 #include <utility>
 
-#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/Objects/CImage.h"
 #include "WallpaperEngine/Core/Objects/Effects/Constants/CShaderConstant.h"
 #include "WallpaperEngine/Core/Objects/Effects/Constants/CShaderConstantFloat.h"
@@ -30,17 +29,17 @@ CEffect::CEffect (
 
 CEffect* CEffect::fromJSON (json data, Core::CObject* object)
 {
-    auto file_it = jsonFindRequired (&data, "file", "Object effect must have a file");
+    auto file_it = jsonFindRequired (data, "file", "Object effect must have a file");
     auto effectpasses_it = data.find ("passes");
 
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile ((*file_it).get <std::string> ().c_str ()));
 
-    auto name_it = jsonFindRequired (&content, "name", "Effect must have a name");
-    auto description_it = jsonFindRequired (&content, "description", "Effect must have a description");
-    auto group_it = jsonFindRequired (&content, "group", "Effect must have a group");
-    auto preview_it = jsonFindRequired (&content, "preview", "Effect must have a preview");
-    auto passes_it = jsonFindRequired (&content, "passes", "Effect must have a pass list");
-    auto dependencies_it = jsonFindRequired (&content, "dependencies", "");
+    auto name_it = jsonFindRequired (content, "name", "Effect must have a name");
+    auto description_it = jsonFindRequired (content, "description", "Effect must have a description");
+    auto group_it = jsonFindRequired (content, "group", "Effect must have a group");
+    auto preview_it = jsonFindRequired (content, "preview", "Effect must have a preview");
+    auto passes_it = jsonFindRequired (content, "passes", "Effect must have a pass list");
+    auto dependencies_it = jsonFindRequired (content, "dependencies", "");
     auto fbos_it = content.find ("fbos");
 
     CEffect* effect = new CEffect (

--- a/src/WallpaperEngine/Core/Objects/CEffect.cpp
+++ b/src/WallpaperEngine/Core/Objects/CEffect.cpp
@@ -30,53 +30,18 @@ CEffect::CEffect (
 
 CEffect* CEffect::fromJSON (json data, Core::CObject* object)
 {
-    auto file_it = data.find ("file");
+    auto file_it = jsonFindValueRequired(&data, "file", "Object effect must have a file");
     auto effectpasses_it = data.find ("passes");
-
-    if (file_it == data.end ())
-    {
-        throw std::runtime_error ("Object effect must have a file");
-    }
 
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile ((*file_it).get <std::string> ().c_str ()));
 
-    auto name_it = content.find ("name");
-    auto description_it = content.find ("description");
-    auto group_it = content.find ("group");
-    auto preview_it = content.find ("preview");
-    auto passes_it = content.find ("passes");
-    auto dependencies_it = content.find ("dependencies");
+    auto name_it = jsonFindValueRequired(&content, "name", "Effect must have a name");
+    auto description_it = jsonFindValueRequired(&content, "description", "Effect must have a description");
+    auto group_it = jsonFindValueRequired(&content, "group", "Effect must have a group");
+    auto preview_it = jsonFindValueRequired(&content, "preview", "Effect must have a preview");
+    auto passes_it = jsonFindValueRequired(&content, "passes", "Effect must have a pass list");
+    auto dependencies_it = jsonFindValueRequired(&content, "dependencies", "");
     auto fbos_it = content.find ("fbos");
-
-    if (name_it == content.end ())
-    {
-        throw std::runtime_error ("Effect must have a name");
-    }
-
-    if (description_it == content.end ())
-    {
-        throw std::runtime_error ("Effect must have a description");
-    }
-
-    if (group_it == content.end ())
-    {
-        throw std::runtime_error ("Effect must have a group");
-    }
-
-    if (preview_it == content.end ())
-    {
-        throw std::runtime_error ("Effect must have a preview");
-    }
-
-    if (passes_it == content.end ())
-    {
-        throw std::runtime_error ("Effect must have a pass list");
-    }
-
-    if (dependencies_it == content.end ())
-    {
-        throw std::runtime_error ("Effect must have dependencies");
-    }
 
     CEffect* effect = new CEffect (
         *name_it,

--- a/src/WallpaperEngine/Core/Objects/CEffect.cpp
+++ b/src/WallpaperEngine/Core/Objects/CEffect.cpp
@@ -30,17 +30,17 @@ CEffect::CEffect (
 
 CEffect* CEffect::fromJSON (json data, Core::CObject* object)
 {
-    auto file_it = jsonFindValueRequired(&data, "file", "Object effect must have a file");
+    auto file_it = jsonFindRequired (&data, "file", "Object effect must have a file");
     auto effectpasses_it = data.find ("passes");
 
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile ((*file_it).get <std::string> ().c_str ()));
 
-    auto name_it = jsonFindValueRequired(&content, "name", "Effect must have a name");
-    auto description_it = jsonFindValueRequired(&content, "description", "Effect must have a description");
-    auto group_it = jsonFindValueRequired(&content, "group", "Effect must have a group");
-    auto preview_it = jsonFindValueRequired(&content, "preview", "Effect must have a preview");
-    auto passes_it = jsonFindValueRequired(&content, "passes", "Effect must have a pass list");
-    auto dependencies_it = jsonFindValueRequired(&content, "dependencies", "");
+    auto name_it = jsonFindRequired (&content, "name", "Effect must have a name");
+    auto description_it = jsonFindRequired (&content, "description", "Effect must have a description");
+    auto group_it = jsonFindRequired (&content, "group", "Effect must have a group");
+    auto preview_it = jsonFindRequired (&content, "preview", "Effect must have a preview");
+    auto passes_it = jsonFindRequired (&content, "passes", "Effect must have a pass list");
+    auto dependencies_it = jsonFindRequired (&content, "dependencies", "");
     auto fbos_it = content.find ("fbos");
 
     CEffect* effect = new CEffect (

--- a/src/WallpaperEngine/Core/Objects/CEffect.h
+++ b/src/WallpaperEngine/Core/Objects/CEffect.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
 
+#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/Objects/Effects/CFBO.h"
 #include "WallpaperEngine/Core/Objects/Effects/Constants/CShaderConstant.h"
 #include "WallpaperEngine/Core/CObject.h"

--- a/src/WallpaperEngine/Core/Objects/CImage.cpp
+++ b/src/WallpaperEngine/Core/Objects/CImage.cpp
@@ -31,21 +31,11 @@ WallpaperEngine::Core::CObject* CImage::fromJSON (
     const irr::core::vector3df& angles)
 {
     auto image_it = data.find ("image");
-    auto size_it = data.find ("size");
-
-    if (size_it == data.end ())
-    {
-        throw std::runtime_error ("Images must have size");
-    }
+    auto size_it = jsonFindValueRequired(&data, "size", "Images must have size");
 
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile ((*image_it).get <std::string> ().c_str ()));
 
-    auto material_it = content.find ("material");
-
-    if (material_it == content.end ())
-    {
-        throw std::runtime_error ("Image must have a material");
-    }
+    auto material_it = jsonFindValueRequired(&content, "material", "Image must have a material");
 
     return new CImage (
         Images::CMaterial::fromFile ((*material_it).get <std::string> ().c_str ()),

--- a/src/WallpaperEngine/Core/Objects/CImage.cpp
+++ b/src/WallpaperEngine/Core/Objects/CImage.cpp
@@ -31,11 +31,11 @@ WallpaperEngine::Core::CObject* CImage::fromJSON (
     const irr::core::vector3df& angles)
 {
     auto image_it = data.find ("image");
-    auto size_it = jsonFindValueRequired(&data, "size", "Images must have size");
+    auto size_it = jsonFindRequired (&data, "size", "Images must have size");
 
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile ((*image_it).get <std::string> ().c_str ()));
 
-    auto material_it = jsonFindValueRequired(&content, "material", "Image must have a material");
+    auto material_it = jsonFindRequired (&content, "material", "Image must have a material");
 
     return new CImage (
         Images::CMaterial::fromFile ((*material_it).get <std::string> ().c_str ()),

--- a/src/WallpaperEngine/Core/Objects/CImage.cpp
+++ b/src/WallpaperEngine/Core/Objects/CImage.cpp
@@ -1,7 +1,6 @@
 #include "CImage.h"
 #include "WallpaperEngine/Core/Objects/Images/CMaterial.h"
 
-#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/FileSystem/FileSystem.h"
 
 using namespace WallpaperEngine::Core::Objects;
@@ -31,11 +30,11 @@ WallpaperEngine::Core::CObject* CImage::fromJSON (
     const irr::core::vector3df& angles)
 {
     auto image_it = data.find ("image");
-    auto size_it = jsonFindRequired (&data, "size", "Images must have size");
+    auto size_it = jsonFindRequired (data, "size", "Images must have size");
 
     json content = json::parse (WallpaperEngine::FileSystem::loadFullFile ((*image_it).get <std::string> ().c_str ()));
 
-    auto material_it = jsonFindRequired (&content, "material", "Image must have a material");
+    auto material_it = jsonFindRequired (content, "material", "Image must have a material");
 
     return new CImage (
         Images::CMaterial::fromFile ((*material_it).get <std::string> ().c_str ()),

--- a/src/WallpaperEngine/Core/Objects/CImage.h
+++ b/src/WallpaperEngine/Core/Objects/CImage.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
 
 #include "WallpaperEngine/Core/Objects/Images/CMaterial.h"
 
+#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/CObject.h"
 
 namespace WallpaperEngine::Core::Objects

--- a/src/WallpaperEngine/Core/Objects/CParticle.cpp
+++ b/src/WallpaperEngine/Core/Objects/CParticle.cpp
@@ -15,10 +15,10 @@ CParticle* CParticle::fromFile (
 {
     json data = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
     auto controlpoint_it = data.find ("controlpoint");
-    auto starttime_it = jsonFindValueRequired(&data, "starttime", "Particles must have start time");
-    auto maxcount_it = jsonFindValueRequired(&data, "maxcount", "Particles must have maximum count");
-    auto emitter_it = jsonFindValueRequired(&data, "emitter", "Particles must have emitters");
-    auto initializer_it = jsonFindValueRequired(&data, "initializer", "Particles must have initializers");
+    auto starttime_it = jsonFindRequired (&data, "starttime", "Particles must have start time");
+    auto maxcount_it = jsonFindRequired (&data, "maxcount", "Particles must have maximum count");
+    auto emitter_it = jsonFindRequired (&data, "emitter", "Particles must have emitters");
+    auto initializer_it = jsonFindRequired (&data, "initializer", "Particles must have initializers");
 
     CParticle* particle = new CParticle (
         *starttime_it,

--- a/src/WallpaperEngine/Core/Objects/CParticle.cpp
+++ b/src/WallpaperEngine/Core/Objects/CParticle.cpp
@@ -1,5 +1,6 @@
 #include "CParticle.h"
 #include "WallpaperEngine/FileSystem/FileSystem.h"
+#include "WallpaperEngine/Core/Core.h"
 
 #include <irrlicht/irrlicht.h>
 
@@ -14,30 +15,10 @@ CParticle* CParticle::fromFile (
 {
     json data = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
     auto controlpoint_it = data.find ("controlpoint");
-    auto starttime_it = data.find ("starttime");
-    auto maxcount_it = data.find ("maxcount");
-    auto emitter_it = data.find ("emitter");
-    auto initializer_it = data.find ("initializer");
-
-    if (starttime_it == data.end ())
-    {
-        throw std::runtime_error ("Particles must have start time");
-    }
-
-    if (maxcount_it == data.end ())
-    {
-        throw std::runtime_error ("Particles must have maximum count");
-    }
-
-    if (emitter_it == data.end ())
-    {
-        throw std::runtime_error ("Particles must have emitters");
-    }
-
-    if (initializer_it == data.end ())
-    {
-        throw std::runtime_error ("Particles must have initializers");
-    }
+    auto starttime_it = jsonFindValueRequired(&data, "starttime", "Particles must have start time");
+    auto maxcount_it = jsonFindValueRequired(&data, "maxcount", "Particles must have maximum count");
+    auto emitter_it = jsonFindValueRequired(&data, "emitter", "Particles must have emitters");
+    auto initializer_it = jsonFindValueRequired(&data, "initializer", "Particles must have initializers");
 
     CParticle* particle = new CParticle (
         *starttime_it,

--- a/src/WallpaperEngine/Core/Objects/CParticle.cpp
+++ b/src/WallpaperEngine/Core/Objects/CParticle.cpp
@@ -1,6 +1,5 @@
 #include "CParticle.h"
 #include "WallpaperEngine/FileSystem/FileSystem.h"
-#include "WallpaperEngine/Core/Core.h"
 
 #include <irrlicht/irrlicht.h>
 
@@ -15,10 +14,10 @@ CParticle* CParticle::fromFile (
 {
     json data = json::parse (WallpaperEngine::FileSystem::loadFullFile (filename));
     auto controlpoint_it = data.find ("controlpoint");
-    auto starttime_it = jsonFindRequired (&data, "starttime", "Particles must have start time");
-    auto maxcount_it = jsonFindRequired (&data, "maxcount", "Particles must have maximum count");
-    auto emitter_it = jsonFindRequired (&data, "emitter", "Particles must have emitters");
-    auto initializer_it = jsonFindRequired (&data, "initializer", "Particles must have initializers");
+    auto starttime_it = jsonFindRequired (data, "starttime", "Particles must have start time");
+    auto maxcount_it = jsonFindRequired (data, "maxcount", "Particles must have maximum count");
+    auto emitter_it = jsonFindRequired (data, "emitter", "Particles must have emitters");
+    auto initializer_it = jsonFindRequired (data, "initializer", "Particles must have initializers");
 
     CParticle* particle = new CParticle (
         *starttime_it,

--- a/src/WallpaperEngine/Core/Objects/CParticle.h
+++ b/src/WallpaperEngine/Core/Objects/CParticle.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <irrlicht/irrlicht.h>
-#include <nlohmann/json.hpp>
 
 #include "WallpaperEngine/Core/Objects/Particles/CControlPoint.h"
 #include "WallpaperEngine/Core/Objects/Particles/CEmitter.h"
 #include "WallpaperEngine/Core/Objects/Particles/CInitializer.h"
 
+#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/CObject.h"
 
 namespace WallpaperEngine::Core::Objects

--- a/src/WallpaperEngine/Core/Objects/CSound.cpp
+++ b/src/WallpaperEngine/Core/Objects/CSound.cpp
@@ -3,8 +3,6 @@
 #include "WallpaperEngine/Core/CObject.h"
 #include "CSound.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects;
 
 CSound::CSound (
@@ -27,7 +25,7 @@ WallpaperEngine::Core::CObject* CSound::fromJSON (
         const irr::core::vector3df& scale,
         const irr::core::vector3df& angles)
 {
-    auto sound_it = jsonFindRequired (&data, "sound", "Sound information not present");
+    auto sound_it = jsonFindRequired (data, "sound", "Sound information not present");
 
     if ((*sound_it).is_array () == false)
     {

--- a/src/WallpaperEngine/Core/Objects/CSound.cpp
+++ b/src/WallpaperEngine/Core/Objects/CSound.cpp
@@ -27,7 +27,7 @@ WallpaperEngine::Core::CObject* CSound::fromJSON (
         const irr::core::vector3df& scale,
         const irr::core::vector3df& angles)
 {
-    auto sound_it = jsonFindValueRequired(&data, "sound", "Sound information not present");
+    auto sound_it = jsonFindRequired (&data, "sound", "Sound information not present");
 
     if ((*sound_it).is_array () == false)
     {

--- a/src/WallpaperEngine/Core/Objects/CSound.cpp
+++ b/src/WallpaperEngine/Core/Objects/CSound.cpp
@@ -3,6 +3,8 @@
 #include "WallpaperEngine/Core/CObject.h"
 #include "CSound.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 using namespace WallpaperEngine::Core::Objects;
 
 CSound::CSound (
@@ -25,12 +27,7 @@ WallpaperEngine::Core::CObject* CSound::fromJSON (
         const irr::core::vector3df& scale,
         const irr::core::vector3df& angles)
 {
-    auto sound_it = data.find ("sound");
-
-    if (sound_it == data.end ())
-    {
-        throw std::runtime_error ("Sound information not present");
-    }
+    auto sound_it = jsonFindValueRequired(&data, "sound", "Sound information not present");
 
     if ((*sound_it).is_array () == false)
     {

--- a/src/WallpaperEngine/Core/Objects/CSound.h
+++ b/src/WallpaperEngine/Core/Objects/CSound.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <irrlicht/irrlicht.h>
-#include <nlohmann/json.hpp>
 
+#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/CObject.h"
 
 namespace WallpaperEngine::Core::Objects

--- a/src/WallpaperEngine/Core/Objects/Effects/CBind.cpp
+++ b/src/WallpaperEngine/Core/Objects/Effects/CBind.cpp
@@ -14,8 +14,8 @@ CBind::CBind (std::string name, irr::u32 index) :
 
 CBind* CBind::fromJSON (json data)
 {
-    auto name_it = jsonFindValueRequired(&data, "name", "bind must have texture name");
-    auto index_it = jsonFindValueRequired(&data, "index", "bind must have index");
+    auto name_it = jsonFindRequired (&data, "name", "bind must have texture name");
+    auto index_it = jsonFindRequired (&data, "index", "bind must have index");
 
     return new CBind (*name_it, *index_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Effects/CBind.cpp
+++ b/src/WallpaperEngine/Core/Objects/Effects/CBind.cpp
@@ -1,7 +1,5 @@
 #include "CBind.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 #include <utility>
 
 using namespace WallpaperEngine::Core::Objects::Effects;
@@ -14,8 +12,8 @@ CBind::CBind (std::string name, irr::u32 index) :
 
 CBind* CBind::fromJSON (json data)
 {
-    auto name_it = jsonFindRequired (&data, "name", "bind must have texture name");
-    auto index_it = jsonFindRequired (&data, "index", "bind must have index");
+    auto name_it = jsonFindRequired (data, "name", "bind must have texture name");
+    auto index_it = jsonFindRequired (data, "index", "bind must have index");
 
     return new CBind (*name_it, *index_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Effects/CBind.cpp
+++ b/src/WallpaperEngine/Core/Objects/Effects/CBind.cpp
@@ -1,5 +1,7 @@
 #include "CBind.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 #include <utility>
 
 using namespace WallpaperEngine::Core::Objects::Effects;
@@ -12,18 +14,8 @@ CBind::CBind (std::string name, irr::u32 index) :
 
 CBind* CBind::fromJSON (json data)
 {
-    auto name_it = data.find ("name");
-    auto index_it = data.find ("index");
-
-    if (name_it == data.end ())
-    {
-        throw std::runtime_error ("bind must have texture name");
-    }
-
-    if (index_it == data.end ())
-    {
-        throw std::runtime_error ("bind must have index");
-    }
+    auto name_it = jsonFindValueRequired(&data, "name", "bind must have texture name");
+    auto index_it = jsonFindValueRequired(&data, "index", "bind must have index");
 
     return new CBind (*name_it, *index_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Effects/CBind.h
+++ b/src/WallpaperEngine/Core/Objects/Effects/CBind.h
@@ -3,7 +3,8 @@
 #include <string>
 
 #include <irrlicht/irrlicht.h>
-#include <nlohmann/json.hpp>
+
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Objects::Effects
 {

--- a/src/WallpaperEngine/Core/Objects/Images/CMaterial.cpp
+++ b/src/WallpaperEngine/Core/Objects/Images/CMaterial.cpp
@@ -3,6 +3,7 @@
 #include <irrlicht/irrlicht.h>
 #include <nlohmann/json.hpp>
 
+#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/FileSystem/FileSystem.h"
 
 using namespace WallpaperEngine::Core::Objects;
@@ -37,12 +38,7 @@ CMaterial* CMaterial::fromJSON (json data, const std::string& target)
 
 CMaterial* CMaterial::fromJSON (json data)
 {
-    auto passes_it = data.find ("passes");
-
-    if (passes_it == data.end ())
-    {
-        throw std::runtime_error ("Material must have at least one pass");
-    }
+    auto passes_it = jsonFindValueRequired(&data, "passes", "Material must have at least one pass");
 
     CMaterial* material = new CMaterial ();
 

--- a/src/WallpaperEngine/Core/Objects/Images/CMaterial.cpp
+++ b/src/WallpaperEngine/Core/Objects/Images/CMaterial.cpp
@@ -38,7 +38,7 @@ CMaterial* CMaterial::fromJSON (json data, const std::string& target)
 
 CMaterial* CMaterial::fromJSON (json data)
 {
-    auto passes_it = jsonFindValueRequired(&data, "passes", "Material must have at least one pass");
+    auto passes_it = jsonFindRequired (&data, "passes", "Material must have at least one pass");
 
     CMaterial* material = new CMaterial ();
 

--- a/src/WallpaperEngine/Core/Objects/Images/CMaterial.cpp
+++ b/src/WallpaperEngine/Core/Objects/Images/CMaterial.cpp
@@ -3,7 +3,6 @@
 #include <irrlicht/irrlicht.h>
 #include <nlohmann/json.hpp>
 
-#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/FileSystem/FileSystem.h"
 
 using namespace WallpaperEngine::Core::Objects;
@@ -38,7 +37,7 @@ CMaterial* CMaterial::fromJSON (json data, const std::string& target)
 
 CMaterial* CMaterial::fromJSON (json data)
 {
-    auto passes_it = jsonFindRequired (&data, "passes", "Material must have at least one pass");
+    auto passes_it = jsonFindRequired (data, "passes", "Material must have at least one pass");
 
     CMaterial* material = new CMaterial ();
 

--- a/src/WallpaperEngine/Core/Objects/Images/CMaterial.h
+++ b/src/WallpaperEngine/Core/Objects/Images/CMaterial.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <irrlicht/irrlicht.h>
-#include <nlohmann/json.hpp>
 
 #include "WallpaperEngine/Core/Objects/Images/Materials/CPass.h"
 #include "WallpaperEngine/Core/Objects/Effects/CBind.h"
+
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Objects::Images
 {

--- a/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.cpp
+++ b/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.cpp
@@ -16,11 +16,11 @@ CPass::CPass (std::string blending, std::string cullmode, std::string depthtest,
 
 CPass* CPass::fromJSON (json data)
 {
-    auto blending_it = jsonFindValueRequired(&data, "blending", "Material pass must have blending specified");
-    auto cullmode_it = jsonFindValueRequired(&data, "cullmode", "Material pass must have cullmode specified");
-    auto depthtest_it = jsonFindValueRequired(&data, "depthtest", "Material pass must have depthtest specified");
-    auto depthwrite_it = jsonFindValueRequired(&data, "depthwrite", "Material pass must have depthwrite specified");
-    auto shader_it = jsonFindValueRequired(&data, "shader", "Material pass must have shader specified");
+    auto blending_it = jsonFindRequired (&data, "blending", "Material pass must have blending specified");
+    auto cullmode_it = jsonFindRequired (&data, "cullmode", "Material pass must have cullmode specified");
+    auto depthtest_it = jsonFindRequired (&data, "depthtest", "Material pass must have depthtest specified");
+    auto depthwrite_it = jsonFindRequired (&data, "depthwrite", "Material pass must have depthwrite specified");
+    auto shader_it = jsonFindRequired (&data, "shader", "Material pass must have shader specified");
     auto textures_it = data.find ("textures");
     auto combos_it = data.find ("combos");
 

--- a/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.cpp
+++ b/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.cpp
@@ -1,5 +1,7 @@
 #include "CPass.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 using namespace WallpaperEngine::Core::Objects::Effects::Constants;
 using namespace WallpaperEngine::Core::Objects::Images::Materials;
 
@@ -14,38 +16,13 @@ CPass::CPass (std::string blending, std::string cullmode, std::string depthtest,
 
 CPass* CPass::fromJSON (json data)
 {
-    auto blending_it = data.find ("blending");
-    auto cullmode_it = data.find ("cullmode");
-    auto depthtest_it = data.find ("depthtest");
-    auto depthwrite_it = data.find ("depthwrite");
-    auto shader_it = data.find ("shader");
+    auto blending_it = jsonFindValueRequired(&data, "blending", "Material pass must have blending specified");
+    auto cullmode_it = jsonFindValueRequired(&data, "cullmode", "Material pass must have cullmode specified");
+    auto depthtest_it = jsonFindValueRequired(&data, "depthtest", "Material pass must have depthtest specified");
+    auto depthwrite_it = jsonFindValueRequired(&data, "depthwrite", "Material pass must have depthwrite specified");
+    auto shader_it = jsonFindValueRequired(&data, "shader", "Material pass must have shader specified");
     auto textures_it = data.find ("textures");
     auto combos_it = data.find ("combos");
-
-    if (blending_it == data.end ())
-    {
-        throw std::runtime_error ("Material pass must have blending specified");
-    }
-
-    if (cullmode_it == data.end ())
-    {
-        throw std::runtime_error ("Material pass must have cullmode specified");
-    }
-
-    if (depthtest_it == data.end ())
-    {
-        throw std::runtime_error ("Material pass must have depthtest specified");
-    }
-
-    if (depthwrite_it == data.end ())
-    {
-        throw std::runtime_error ("Material pass must have depthwrite specified");
-    }
-
-    if (shader_it == data.end ())
-    {
-        throw std::runtime_error ("Material pass must have shader specified");
-    }
 
     if (textures_it != data.end ())
     {

--- a/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.cpp
+++ b/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.cpp
@@ -1,7 +1,5 @@
 #include "CPass.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Effects::Constants;
 using namespace WallpaperEngine::Core::Objects::Images::Materials;
 
@@ -16,11 +14,11 @@ CPass::CPass (std::string blending, std::string cullmode, std::string depthtest,
 
 CPass* CPass::fromJSON (json data)
 {
-    auto blending_it = jsonFindRequired (&data, "blending", "Material pass must have blending specified");
-    auto cullmode_it = jsonFindRequired (&data, "cullmode", "Material pass must have cullmode specified");
-    auto depthtest_it = jsonFindRequired (&data, "depthtest", "Material pass must have depthtest specified");
-    auto depthwrite_it = jsonFindRequired (&data, "depthwrite", "Material pass must have depthwrite specified");
-    auto shader_it = jsonFindRequired (&data, "shader", "Material pass must have shader specified");
+    auto blending_it = jsonFindRequired (data, "blending", "Material pass must have blending specified");
+    auto cullmode_it = jsonFindRequired (data, "cullmode", "Material pass must have cullmode specified");
+    auto depthtest_it = jsonFindRequired (data, "depthtest", "Material pass must have depthtest specified");
+    auto depthwrite_it = jsonFindRequired (data, "depthwrite", "Material pass must have depthwrite specified");
+    auto shader_it = jsonFindRequired (data, "shader", "Material pass must have shader specified");
     auto textures_it = data.find ("textures");
     auto combos_it = data.find ("combos");
 

--- a/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.h
+++ b/src/WallpaperEngine/Core/Objects/Images/Materials/CPass.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
 
 #include "WallpaperEngine/Core/Objects/Effects/Constants/CShaderConstant.h"
 

--- a/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.cpp
@@ -7,7 +7,7 @@ using namespace WallpaperEngine::Core::Objects::Particles;
 CControlPoint* CControlPoint::fromJSON (json data)
 {
     auto flags_it = data.find ("flags");
-    auto id_it = jsonFindValueRequired(&data, "id", "Particle's control point must have id");
+    auto id_it = jsonFindRequired (&data, "id", "Particle's control point must have id");
     auto offset_it = data.find ("offset");
 
     CControlPoint* controlpoint = new CControlPoint (*id_it, 0);

--- a/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.cpp
@@ -1,13 +1,11 @@
 #include "CControlPoint.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles;
 
 CControlPoint* CControlPoint::fromJSON (json data)
 {
     auto flags_it = data.find ("flags");
-    auto id_it = jsonFindRequired (&data, "id", "Particle's control point must have id");
+    auto id_it = jsonFindRequired (data, "id", "Particle's control point must have id");
     auto offset_it = data.find ("offset");
 
     CControlPoint* controlpoint = new CControlPoint (*id_it, 0);

--- a/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.cpp
@@ -7,13 +7,8 @@ using namespace WallpaperEngine::Core::Objects::Particles;
 CControlPoint* CControlPoint::fromJSON (json data)
 {
     auto flags_it = data.find ("flags");
-    auto id_it = data.find ("id");
+    auto id_it = jsonFindValueRequired(&data, "id", "Particle's control point must have id");
     auto offset_it = data.find ("offset");
-
-    if (id_it == data.end ())
-    {
-        throw std::runtime_error ("Particle's control point must have id");
-    }
 
     CControlPoint* controlpoint = new CControlPoint (*id_it, 0);
 

--- a/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/CControlPoint.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
+
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Objects::Particles
 {

--- a/src/WallpaperEngine/Core/Objects/Particles/CEmitter.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CEmitter.cpp
@@ -1,18 +1,16 @@
 #include "CEmitter.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles;
 
 CEmitter* CEmitter::fromJSON (json data)
 {
-    auto directions_it = jsonFindRequired (&data, "directions", "Particle emitter must have direction specified");
-    auto distancemax_it = jsonFindRequired (&data, "distancemax", "Particle emitter must have maximum distance");
-    auto distancemin_it = jsonFindRequired (&data, "distancemin", "Particle emitter must have minimum distance");
+    auto directions_it = jsonFindRequired (data, "directions", "Particle emitter must have direction specified");
+    auto distancemax_it = jsonFindRequired (data, "distancemax", "Particle emitter must have maximum distance");
+    auto distancemin_it = jsonFindRequired (data, "distancemin", "Particle emitter must have minimum distance");
     auto id_it = data.find ("id");
-    auto name_it = jsonFindRequired (&data, "name", "Particle emitter must have a name");
-    auto origin_it = jsonFindRequired (&data, "origin", "Particle emitter must have an origin");
-    auto rate_it = jsonFindRequired (&data, "rate", "Particle emitter must have a rate");
+    auto name_it = jsonFindRequired (data, "name", "Particle emitter must have a name");
+    auto origin_it = jsonFindRequired (data, "origin", "Particle emitter must have an origin");
+    auto rate_it = jsonFindRequired (data, "rate", "Particle emitter must have a rate");
 
     return new CEmitter (
             WallpaperEngine::Core::ato3vf (*directions_it),

--- a/src/WallpaperEngine/Core/Objects/Particles/CEmitter.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CEmitter.cpp
@@ -6,43 +6,13 @@ using namespace WallpaperEngine::Core::Objects::Particles;
 
 CEmitter* CEmitter::fromJSON (json data)
 {
-    auto directions_it = data.find ("directions");
-    auto distancemax_it = data.find ("distancemax");
-    auto distancemin_it = data.find ("distancemin");
+    auto directions_it = jsonFindValueRequired(&data, "directions", "Particle emitter must have direction specified");
+    auto distancemax_it = jsonFindValueRequired(&data, "distancemax", "Particle emitter must have maximum distance");
+    auto distancemin_it = jsonFindValueRequired(&data, "distancemin", "Particle emitter must have minimum distance");
     auto id_it = data.find ("id");
-    auto name_it = data.find ("name");
-    auto origin_it = data.find ("origin");
-    auto rate_it = data.find ("rate");
-
-    if (directions_it == data.end ())
-    {
-        throw std::runtime_error ("Particle emitter must have direction specified");
-    }
-
-    if (distancemax_it == data.end ())
-    {
-        throw std::runtime_error ("Particle emitter must have maximum distance");
-    }
-
-    if (distancemin_it == data.end ())
-    {
-        throw std::runtime_error ("Particle emitter must have minimum distance");
-    }
-
-    if (name_it == data.end ())
-    {
-        throw std::runtime_error ("Particle emitter must have a name");
-    }
-
-    if (origin_it == data.end ())
-    {
-        throw std::runtime_error ("Particle emitter must have an origin");
-    }
-
-    if (rate_it == data.end ())
-    {
-        throw std::runtime_error ("Particle emitter must have a rate");
-    }
+    auto name_it = jsonFindValueRequired(&data, "name", "Particle emitter must have a name");
+    auto origin_it = jsonFindValueRequired(&data, "origin", "Particle emitter must have an origin");
+    auto rate_it = jsonFindValueRequired(&data, "rate", "Particle emitter must have a rate");
 
     return new CEmitter (
             WallpaperEngine::Core::ato3vf (*directions_it),

--- a/src/WallpaperEngine/Core/Objects/Particles/CEmitter.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CEmitter.cpp
@@ -6,13 +6,13 @@ using namespace WallpaperEngine::Core::Objects::Particles;
 
 CEmitter* CEmitter::fromJSON (json data)
 {
-    auto directions_it = jsonFindValueRequired(&data, "directions", "Particle emitter must have direction specified");
-    auto distancemax_it = jsonFindValueRequired(&data, "distancemax", "Particle emitter must have maximum distance");
-    auto distancemin_it = jsonFindValueRequired(&data, "distancemin", "Particle emitter must have minimum distance");
+    auto directions_it = jsonFindRequired (&data, "directions", "Particle emitter must have direction specified");
+    auto distancemax_it = jsonFindRequired (&data, "distancemax", "Particle emitter must have maximum distance");
+    auto distancemin_it = jsonFindRequired (&data, "distancemin", "Particle emitter must have minimum distance");
     auto id_it = data.find ("id");
-    auto name_it = jsonFindValueRequired(&data, "name", "Particle emitter must have a name");
-    auto origin_it = jsonFindValueRequired(&data, "origin", "Particle emitter must have an origin");
-    auto rate_it = jsonFindValueRequired(&data, "rate", "Particle emitter must have a rate");
+    auto name_it = jsonFindRequired (&data, "name", "Particle emitter must have a name");
+    auto origin_it = jsonFindRequired (&data, "origin", "Particle emitter must have an origin");
+    auto rate_it = jsonFindRequired (&data, "rate", "Particle emitter must have a rate");
 
     return new CEmitter (
             WallpaperEngine::Core::ato3vf (*directions_it),

--- a/src/WallpaperEngine/Core/Objects/Particles/CEmitter.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/CEmitter.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
+
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Objects::Particles
 {

--- a/src/WallpaperEngine/Core/Objects/Particles/CInitializer.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CInitializer.cpp
@@ -1,5 +1,6 @@
 #include "CInitializer.h"
 
+#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.h"
 #include "WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.h"
 #include "WallpaperEngine/Core/Objects/Particles/Initializers/CRotationRandom.h"
@@ -13,13 +14,8 @@ using namespace WallpaperEngine::Core::Objects::Particles;
 CInitializer* CInitializer::fromJSON (json data)
 {
     auto id_it = data.find ("id");
-    auto name_it = data.find ("name");
+    auto name_it = jsonFindValueRequired(&data, "name", "Particle's initializer must have a name");
     irr::u32 id = ((id_it == data.end ()) ? 0 : (irr::u32) (*id_it));
-
-    if (name_it == data.end ())
-    {
-        throw std::runtime_error ("Particle's initializer must have a name");
-    }
 
     if (*name_it == "lifetimerandom")
     {

--- a/src/WallpaperEngine/Core/Objects/Particles/CInitializer.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CInitializer.cpp
@@ -1,6 +1,5 @@
 #include "CInitializer.h"
 
-#include "WallpaperEngine/Core/Core.h"
 #include "WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.h"
 #include "WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.h"
 #include "WallpaperEngine/Core/Objects/Particles/Initializers/CRotationRandom.h"
@@ -14,7 +13,7 @@ using namespace WallpaperEngine::Core::Objects::Particles;
 CInitializer* CInitializer::fromJSON (json data)
 {
     auto id_it = data.find ("id");
-    auto name_it = jsonFindRequired (&data, "name", "Particle's initializer must have a name");
+    auto name_it = jsonFindRequired (data, "name", "Particle's initializer must have a name");
     irr::u32 id = ((id_it == data.end ()) ? 0 : (irr::u32) (*id_it));
 
     if (*name_it == "lifetimerandom")

--- a/src/WallpaperEngine/Core/Objects/Particles/CInitializer.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/CInitializer.cpp
@@ -14,7 +14,7 @@ using namespace WallpaperEngine::Core::Objects::Particles;
 CInitializer* CInitializer::fromJSON (json data)
 {
     auto id_it = data.find ("id");
-    auto name_it = jsonFindValueRequired(&data, "name", "Particle's initializer must have a name");
+    auto name_it = jsonFindRequired (&data, "name", "Particle's initializer must have a name");
     irr::u32 id = ((id_it == data.end ()) ? 0 : (irr::u32) (*id_it));
 
     if (*name_it == "lifetimerandom")

--- a/src/WallpaperEngine/Core/Objects/Particles/CInitializer.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/CInitializer.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
+
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Objects::Particles
 {

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.cpp
@@ -6,8 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CAlphaRandom* CAlphaRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindValueRequired(&data, "min", "Alpharandom initializer must have a minimum value");
-    auto max_it = jsonFindValueRequired(&data, "max", "Alpharandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (&data, "min", "Alpharandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (&data, "max", "Alpharandom initializer must have a maximum value");
 
     return new CAlphaRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.cpp
@@ -1,13 +1,11 @@
 #include "CAlphaRandom.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CAlphaRandom* CAlphaRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindRequired (&data, "min", "Alpharandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "max", "Alpharandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (data, "min", "Alpharandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (data, "max", "Alpharandom initializer must have a maximum value");
 
     return new CAlphaRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.cpp
@@ -1,21 +1,13 @@
 #include "CAlphaRandom.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CAlphaRandom* CAlphaRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = data.find ("min");
-    auto max_it = data.find ("max");
-
-    if (min_it == data.end ())
-    {
-        throw std::runtime_error ("Alpharandom initializer must have a minimum value");
-    }
-
-    if (max_it == data.end ())
-    {
-        throw std::runtime_error ("Alpharandom initializer must have a maximum value");
-    }
+    auto min_it = jsonFindValueRequired(&data, "min", "Alpharandom initializer must have a minimum value");
+    auto max_it = jsonFindValueRequired(&data, "max", "Alpharandom initializer must have a maximum value");
 
     return new CAlphaRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAlphaRandom.h
@@ -2,7 +2,8 @@
 
 #include "WallpaperEngine/Core/Objects/Particles/CInitializer.h"
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
+
 #include <irrlicht/irrlicht.h>
 
 namespace WallpaperEngine::Core::Objects::Particles::Initializers

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.cpp
@@ -6,8 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CAngularVelocityRandom* CAngularVelocityRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindValueRequired(&data, "min", "Angularvelocityrandom initializer must have a minimum value");
-    auto max_it = jsonFindValueRequired(&data, "max", "Angularvelocityrandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (&data, "min", "Angularvelocityrandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (&data, "max", "Angularvelocityrandom initializer must have a maximum value");
 
     return new CAngularVelocityRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.cpp
@@ -1,13 +1,11 @@
 #include "CAngularVelocityRandom.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CAngularVelocityRandom* CAngularVelocityRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindRequired (&data, "min", "Angularvelocityrandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "max", "Angularvelocityrandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (data, "min", "Angularvelocityrandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (data, "max", "Angularvelocityrandom initializer must have a maximum value");
 
     return new CAngularVelocityRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.cpp
@@ -6,18 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CAngularVelocityRandom* CAngularVelocityRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = data.find ("min");
-    auto max_it = data.find ("max");
-
-    if (min_it == data.end ())
-    {
-        throw std::runtime_error ("Angularvelocityrandom initializer must have a minimum value");
-    }
-
-    if (max_it == data.end ())
-    {
-        throw std::runtime_error ("Angularvelocityrandom initializer must have a maximum value");
-    }
+    auto min_it = jsonFindValueRequired(&data, "min", "Angularvelocityrandom initializer must have a minimum value");
+    auto max_it = jsonFindValueRequired(&data, "max", "Angularvelocityrandom initializer must have a maximum value");
 
     return new CAngularVelocityRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CAngularVelocityRandom.h
@@ -2,7 +2,8 @@
 
 #include "WallpaperEngine/Core/Objects/Particles/CInitializer.h"
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
+
 #include <irrlicht/irrlicht.h>
 
 namespace WallpaperEngine::Core::Objects::Particles::Initializers

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
@@ -1,13 +1,11 @@
 #include "CColorRandom.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CColorRandom* CColorRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindRequired (&data, "min", "Colorrandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "max", "Colorrandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (data, "min", "Colorrandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (data, "max", "Colorrandom initializer must have a maximum value");
 
     return new CColorRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
@@ -6,18 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CColorRandom* CColorRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = data.find ("min");
-    auto max_it = data.find ("max");
-
-    if (min_it == data.end ())
-    {
-        throw std::runtime_error ("Colorrandom initializer must have a minimum value");
-    }
-
-    if (max_it == data.end ())
-    {
-        throw std::runtime_error ("Colorrandom initializer must have a maximum value");
-    }
+    auto min_it = jsonFindValueRequired(&data, "min", "Colorrandom initializer must have a minimum value");
+    auto max_it = jsonFindValueRequired(&data, "min", "Colorrandom initializer must have a maximum value");
 
     return new CColorRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
@@ -6,8 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CColorRandom* CColorRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindValueRequired(&data, "min", "Colorrandom initializer must have a minimum value");
-    auto max_it = jsonFindValueRequired(&data, "min", "Colorrandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (&data, "min", "Colorrandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (&data, "min", "Colorrandom initializer must have a maximum value");
 
     return new CColorRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.cpp
@@ -7,7 +7,7 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 CColorRandom* CColorRandom::fromJSON (json data, irr::u32 id)
 {
     auto min_it = jsonFindRequired (&data, "min", "Colorrandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "min", "Colorrandom initializer must have a maximum value");
+    auto max_it = jsonFindRequired (&data, "max", "Colorrandom initializer must have a maximum value");
 
     return new CColorRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CColorRandom.h
@@ -2,7 +2,8 @@
 
 #include "WallpaperEngine/Core/Objects/Particles/CInitializer.h"
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
+
 #include <irrlicht/irrlicht.h>
 
 namespace WallpaperEngine::Core::Objects::Particles::Initializers

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
@@ -1,21 +1,13 @@
 #include "CLifeTimeRandom.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CLifeTimeRandom* CLifeTimeRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = data.find ("min");
-    auto max_it = data.find ("max");
-
-    if (min_it == data.end ())
-    {
-        throw std::runtime_error ("Lifetimerandom initializer must have a minimum value");
-    }
-
-    if (max_it == data.end ())
-    {
-        throw std::runtime_error ("Lifetimerandom initializer must have a maximum value");
-    }
+    auto min_it = jsonFindValueRequired(&data, "min", "Lifetimerandom initializer must have a minimum value");
+    auto max_it = jsonFindValueRequired(&data, "min", "Lifetimerandom initializer must have a maximum value");
 
     return new CLifeTimeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
@@ -7,7 +7,7 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 CLifeTimeRandom* CLifeTimeRandom::fromJSON (json data, irr::u32 id)
 {
     auto min_it = jsonFindRequired (&data, "min", "Lifetimerandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "min", "Lifetimerandom initializer must have a maximum value");
+    auto max_it = jsonFindRequired (&data, "max", "Lifetimerandom initializer must have a maximum value");
 
     return new CLifeTimeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
@@ -6,8 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CLifeTimeRandom* CLifeTimeRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindValueRequired(&data, "min", "Lifetimerandom initializer must have a minimum value");
-    auto max_it = jsonFindValueRequired(&data, "min", "Lifetimerandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (&data, "min", "Lifetimerandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (&data, "min", "Lifetimerandom initializer must have a maximum value");
 
     return new CLifeTimeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.cpp
@@ -1,13 +1,11 @@
 #include "CLifeTimeRandom.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CLifeTimeRandom* CLifeTimeRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindRequired (&data, "min", "Lifetimerandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "max", "Lifetimerandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (data, "min", "Lifetimerandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (data, "max", "Lifetimerandom initializer must have a maximum value");
 
     return new CLifeTimeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CLifeTimeRandom.h
@@ -2,7 +2,8 @@
 
 #include "WallpaperEngine/Core/Objects/Particles/CInitializer.h"
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
+
 #include <irrlicht/irrlicht.h>
 
 namespace WallpaperEngine::Core::Objects::Particles::Initializers

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
@@ -1,13 +1,11 @@
 #include "CSizeRandom.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CSizeRandom* CSizeRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindRequired (&data, "min", "Sizerandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "max", "Sizerandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (data, "min", "Sizerandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (data, "max", "Sizerandom initializer must have a maximum value");
 
     return new CSizeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
@@ -1,21 +1,13 @@
 #include "CSizeRandom.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CSizeRandom* CSizeRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = data.find ("min");
-    auto max_it = data.find ("max");
-
-    if (min_it == data.end ())
-    {
-        throw std::runtime_error ("Sizerandom initializer must have a minimum value");
-    }
-
-    if (max_it == data.end ())
-    {
-        throw std::runtime_error ("Sizerandom initializer must have a maximum value");
-    }
+    auto min_it = jsonFindValueRequired(&data, "min", "Sizerandom initializer must have a minimum value");
+    auto max_it = jsonFindValueRequired(&data, "min", "Sizerandom initializer must have a maximum value");
 
     return new CSizeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
@@ -6,8 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CSizeRandom* CSizeRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindValueRequired(&data, "min", "Sizerandom initializer must have a minimum value");
-    auto max_it = jsonFindValueRequired(&data, "min", "Sizerandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (&data, "min", "Sizerandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (&data, "min", "Sizerandom initializer must have a maximum value");
 
     return new CSizeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.cpp
@@ -7,7 +7,7 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 CSizeRandom* CSizeRandom::fromJSON (json data, irr::u32 id)
 {
     auto min_it = jsonFindRequired (&data, "min", "Sizerandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "min", "Sizerandom initializer must have a maximum value");
+    auto max_it = jsonFindRequired (&data, "max", "Sizerandom initializer must have a maximum value");
 
     return new CSizeRandom (id, *min_it, *max_it);
 }

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CSizeRandom.h
@@ -2,7 +2,8 @@
 
 #include "WallpaperEngine/Core/Objects/Particles/CInitializer.h"
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
+
 #include <irrlicht/irrlicht.h>
 
 namespace WallpaperEngine::Core::Objects::Particles::Initializers

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.cpp
@@ -1,13 +1,11 @@
 #include "CVelocityRandom.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CVelocityRandom* CVelocityRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindRequired (&data, "min", "Velocityrandom initializer must have a minimum value");
-    auto max_it = jsonFindRequired (&data, "max", "Velocityrandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (data, "min", "Velocityrandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (data, "max", "Velocityrandom initializer must have a maximum value");
 
     return new CVelocityRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.cpp
@@ -6,18 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CVelocityRandom* CVelocityRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = data.find ("min");
-    auto max_it = data.find ("max");
-
-    if (min_it == data.end ())
-    {
-        throw std::runtime_error ("Velocityrandom initializer must have a minimum value");
-    }
-
-    if (max_it == data.end ())
-    {
-        throw std::runtime_error ("Velocityrandom initializer must have a maximum value");
-    }
+    auto min_it = jsonFindValueRequired(&data, "min", "Velocityrandom initializer must have a minimum value");
+    auto max_it = jsonFindValueRequired(&data, "max", "Velocityrandom initializer must have a maximum value");
 
     return new CVelocityRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.cpp
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.cpp
@@ -6,8 +6,8 @@ using namespace WallpaperEngine::Core::Objects::Particles::Initializers;
 
 CVelocityRandom* CVelocityRandom::fromJSON (json data, irr::u32 id)
 {
-    auto min_it = jsonFindValueRequired(&data, "min", "Velocityrandom initializer must have a minimum value");
-    auto max_it = jsonFindValueRequired(&data, "max", "Velocityrandom initializer must have a maximum value");
+    auto min_it = jsonFindRequired (&data, "min", "Velocityrandom initializer must have a minimum value");
+    auto max_it = jsonFindRequired (&data, "max", "Velocityrandom initializer must have a maximum value");
 
     return new CVelocityRandom (
             id,

--- a/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.h
+++ b/src/WallpaperEngine/Core/Objects/Particles/Initializers/CVelocityRandom.h
@@ -2,7 +2,8 @@
 
 #include "WallpaperEngine/Core/Objects/Particles/CInitializer.h"
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
+
 #include <irrlicht/irrlicht.h>
 
 namespace WallpaperEngine::Core::Objects::Particles::Initializers

--- a/src/WallpaperEngine/Core/Projects/CProperty.cpp
+++ b/src/WallpaperEngine/Core/Projects/CProperty.cpp
@@ -7,8 +7,8 @@ using namespace WallpaperEngine::Core::Projects;
 
 CProperty* CProperty::fromJSON (json data, const std::string& name)
 {
-    auto type = jsonFindValueRequired(&data, "type", "Project properties must have the type field");
-    auto value = jsonFindValueRequired(&data, "value", "Project properties must have the value field");
+    auto type = jsonFindRequired (&data, "type", "Project properties must have the type field");
+    auto value = jsonFindRequired (&data, "value", "Project properties must have the value field");
     auto text = data.find ("text");
 
     if (*type == CPropertyColor::Type)

--- a/src/WallpaperEngine/Core/Projects/CProperty.cpp
+++ b/src/WallpaperEngine/Core/Projects/CProperty.cpp
@@ -1,14 +1,12 @@
 #include "CProperty.h"
 #include "CPropertyColor.h"
 
-#include "WallpaperEngine/Core/Core.h"
-
 using namespace WallpaperEngine::Core::Projects;
 
 CProperty* CProperty::fromJSON (json data, const std::string& name)
 {
-    auto type = jsonFindRequired (&data, "type", "Project properties must have the type field");
-    auto value = jsonFindRequired (&data, "value", "Project properties must have the value field");
+    auto type = jsonFindRequired (data, "type", "Project properties must have the type field");
+    auto value = jsonFindRequired (data, "value", "Project properties must have the value field");
     auto text = data.find ("text");
 
     if (*type == CPropertyColor::Type)

--- a/src/WallpaperEngine/Core/Projects/CProperty.cpp
+++ b/src/WallpaperEngine/Core/Projects/CProperty.cpp
@@ -1,23 +1,15 @@
 #include "CProperty.h"
 #include "CPropertyColor.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 using namespace WallpaperEngine::Core::Projects;
 
 CProperty* CProperty::fromJSON (json data, const std::string& name)
 {
-    auto type = data.find ("type");
-    auto value = data.find ("value");
+    auto type = jsonFindValueRequired(&data, "type", "Project properties must have the type field");
+    auto value = jsonFindValueRequired(&data, "value", "Project properties must have the value field");
     auto text = data.find ("text");
-
-    if (value == data.end ())
-    {
-        throw std::runtime_error ("Project properties must have the value field");
-    }
-
-    if (type == data.end ())
-    {
-        throw std::runtime_error ("Project properties must have the type field");
-    }
 
     if (*type == CPropertyColor::Type)
     {

--- a/src/WallpaperEngine/Core/Projects/CProperty.h
+++ b/src/WallpaperEngine/Core/Projects/CProperty.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Projects
 {

--- a/src/WallpaperEngine/Core/Projects/CPropertyColor.cpp
+++ b/src/WallpaperEngine/Core/Projects/CPropertyColor.cpp
@@ -1,5 +1,4 @@
 #include "CPropertyColor.h"
-#include "WallpaperEngine/Core/Core.h"
 
 using namespace WallpaperEngine::Core::Projects;
 

--- a/src/WallpaperEngine/Core/Projects/CPropertyColor.h
+++ b/src/WallpaperEngine/Core/Projects/CPropertyColor.h
@@ -4,6 +4,8 @@
 
 #include "CProperty.h"
 
+#include "WallpaperEngine/Core/Core.h"
+
 namespace WallpaperEngine::Core::Projects
 {
     using json = nlohmann::json;

--- a/src/WallpaperEngine/Core/Scenes/CCamera.cpp
+++ b/src/WallpaperEngine/Core/Scenes/CCamera.cpp
@@ -27,9 +27,9 @@ const irr::core::vector3df& CCamera::getUp () const
 
 CCamera* CCamera::fromJSON (json data)
 {
-    auto center_it = jsonFindValueRequired(&data, "center", "Camera must have a center position");
-    auto eye_it = jsonFindValueRequired(&data, "eye", "Camera must have an eye position");
-    auto up_it = jsonFindValueRequired(&data, "up", "Camera must have a up position");
+    auto center_it = jsonFindRequired (&data, "center", "Camera must have a center position");
+    auto eye_it = jsonFindRequired (&data, "eye", "Camera must have an eye position");
+    auto up_it = jsonFindRequired (&data, "up", "Camera must have a up position");
 
     return new CCamera (
         WallpaperEngine::Core::ato3vf (*center_it),

--- a/src/WallpaperEngine/Core/Scenes/CCamera.cpp
+++ b/src/WallpaperEngine/Core/Scenes/CCamera.cpp
@@ -1,5 +1,4 @@
 #include "CCamera.h"
-#include "WallpaperEngine/Core/Core.h"
 
 using namespace WallpaperEngine::Core::Scenes;
 
@@ -27,9 +26,9 @@ const irr::core::vector3df& CCamera::getUp () const
 
 CCamera* CCamera::fromJSON (json data)
 {
-    auto center_it = jsonFindRequired (&data, "center", "Camera must have a center position");
-    auto eye_it = jsonFindRequired (&data, "eye", "Camera must have an eye position");
-    auto up_it = jsonFindRequired (&data, "up", "Camera must have a up position");
+    auto center_it = jsonFindRequired (data, "center", "Camera must have a center position");
+    auto eye_it = jsonFindRequired (data, "eye", "Camera must have an eye position");
+    auto up_it = jsonFindRequired (data, "up", "Camera must have a up position");
 
     return new CCamera (
         WallpaperEngine::Core::ato3vf (*center_it),

--- a/src/WallpaperEngine/Core/Scenes/CCamera.cpp
+++ b/src/WallpaperEngine/Core/Scenes/CCamera.cpp
@@ -27,24 +27,9 @@ const irr::core::vector3df& CCamera::getUp () const
 
 CCamera* CCamera::fromJSON (json data)
 {
-    auto center_it = data.find ("center");
-    auto eye_it = data.find ("eye");
-    auto up_it = data.find ("up");
-
-    if (center_it == data.end ())
-    {
-        throw std::runtime_error ("Camera must have a center position");
-    }
-
-    if (eye_it == data.end ())
-    {
-        throw std::runtime_error ("Camera must have an eye position");
-    }
-
-    if (up_it == data.end ())
-    {
-        throw std::runtime_error ("Camera must have a up position");
-    }
+    auto center_it = jsonFindValueRequired(&data, "center", "Camera must have a center position");
+    auto eye_it = jsonFindValueRequired(&data, "eye", "Camera must have an eye position");
+    auto up_it = jsonFindValueRequired(&data, "up", "Camera must have a up position");
 
     return new CCamera (
         WallpaperEngine::Core::ato3vf (*center_it),

--- a/src/WallpaperEngine/Core/Scenes/CCamera.h
+++ b/src/WallpaperEngine/Core/Scenes/CCamera.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
+
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Scenes
 {

--- a/src/WallpaperEngine/Core/Scenes/CProjection.cpp
+++ b/src/WallpaperEngine/Core/Scenes/CProjection.cpp
@@ -21,8 +21,8 @@ const irr::u32& CProjection::getHeight () const
 
 CProjection* CProjection::fromJSON (json data)
 {
-    auto width_it = jsonFindValueRequired(&data, "width", "Projection must have width");
-    auto height_it = jsonFindValueRequired(&data, "height", "Projection must have height");
+    auto width_it = jsonFindRequired (&data, "width", "Projection must have width");
+    auto height_it = jsonFindRequired (&data, "height", "Projection must have height");
 
     return new CProjection (
         *width_it,

--- a/src/WallpaperEngine/Core/Scenes/CProjection.cpp
+++ b/src/WallpaperEngine/Core/Scenes/CProjection.cpp
@@ -21,18 +21,8 @@ const irr::u32& CProjection::getHeight () const
 
 CProjection* CProjection::fromJSON (json data)
 {
-    auto width_it = data.find ("width");
-    auto height_it = data.find ("height");
-
-    if (width_it == data.end ())
-    {
-        throw std::runtime_error ("Projection must have width");
-    }
-
-    if (height_it == data.end ())
-    {
-        throw std::runtime_error ("Projection must have height");
-    }
+    auto width_it = jsonFindValueRequired(&data, "width", "Projection must have width");
+    auto height_it = jsonFindValueRequired(&data, "height", "Projection must have height");
 
     return new CProjection (
         *width_it,

--- a/src/WallpaperEngine/Core/Scenes/CProjection.cpp
+++ b/src/WallpaperEngine/Core/Scenes/CProjection.cpp
@@ -1,5 +1,4 @@
 #include "CProjection.h"
-#include "WallpaperEngine/Core/Core.h"
 
 using namespace WallpaperEngine::Core::Scenes;
 
@@ -21,8 +20,8 @@ const irr::u32& CProjection::getHeight () const
 
 CProjection* CProjection::fromJSON (json data)
 {
-    auto width_it = jsonFindRequired (&data, "width", "Projection must have width");
-    auto height_it = jsonFindRequired (&data, "height", "Projection must have height");
+    auto width_it = jsonFindRequired (data, "width", "Projection must have width");
+    auto height_it = jsonFindRequired (data, "height", "Projection must have height");
 
     return new CProjection (
         *width_it,

--- a/src/WallpaperEngine/Core/Scenes/CProjection.h
+++ b/src/WallpaperEngine/Core/Scenes/CProjection.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <irrlicht/irrlicht.h>
+
+#include "WallpaperEngine/Core/Core.h"
 
 namespace WallpaperEngine::Core::Scenes
 {

--- a/src/WallpaperEngine/FileSystem/FileSystem.cpp
+++ b/src/WallpaperEngine/FileSystem/FileSystem.cpp
@@ -1,6 +1,8 @@
 // filesystem includes
 #include "FileSystem.h"
 
+#include <iostream>
+
 // engine includes
 #include "WallpaperEngine/Irrlicht/CContext.h"
 
@@ -10,6 +12,7 @@ using namespace WallpaperEngine;
 
 std::string FileSystem::loadFullFile (const irr::io::path& file)
 {
+    std::cout << file.c_str() << std::endl;
     irr::io::IReadFile* reader = IrrlichtContext->getDevice ()->getFileSystem ()->createAndOpenFile (file);
 
     if (reader == nullptr)

--- a/src/WallpaperEngine/Render/Shaders/Compiler.cpp
+++ b/src/WallpaperEngine/Render/Shaders/Compiler.cpp
@@ -17,6 +17,8 @@
 #include "WallpaperEngine/Render/Shaders/Variables/CShaderVariableVector3.h"
 #include "WallpaperEngine/Render/Shaders/Variables/CShaderVariableVector4.h"
 
+using namespace WallpaperEngine::Core;
+
 namespace WallpaperEngine::Render::Shaders
 {
     Compiler::Compiler (Irrlicht::CContext* context, irr::io::path& file, Type type, const std::map<std::string, int>& combos, bool recursive) :
@@ -483,16 +485,11 @@ namespace WallpaperEngine::Render::Shaders
     void Compiler::parseComboConfiguration (const std::string& content)
     {
         json data = json::parse (content);
-        auto combo = data.find ("combo");
-        auto defvalue = data.find ("default");
+        auto combo = jsonFindValueRequired(&data, "combo", "cannot parse combo information");
+        auto defvalue = jsonFindValueRequired(&data, "default", "cannot parse combo information");
 
         // add line feed just in case
         this->m_compiledContent += "\n";
-
-        if (combo == data.end () || defvalue == data.end ())
-        {
-            throw std::runtime_error ("cannot parse combo information");
-        }
 
         // check the combos
         std::map<std::string, int>::const_iterator entry = this->m_combos.find ((*combo).get <std::string> ());

--- a/src/WallpaperEngine/Render/Shaders/Compiler.cpp
+++ b/src/WallpaperEngine/Render/Shaders/Compiler.cpp
@@ -8,7 +8,6 @@
 
 // shader compiler
 #include <WallpaperEngine/Render/Shaders/Compiler.h>
-#include <WallpaperEngine/Core/Core.h>
 
 #include "WallpaperEngine/Render/Shaders/Variables/CShaderVariable.h"
 #include "WallpaperEngine/Render/Shaders/Variables/CShaderVariableFloat.h"
@@ -485,8 +484,8 @@ namespace WallpaperEngine::Render::Shaders
     void Compiler::parseComboConfiguration (const std::string& content)
     {
         json data = json::parse (content);
-        auto combo = jsonFindRequired (&data, "combo", "cannot parse combo information");
-        auto defvalue = jsonFindRequired (&data, "default", "cannot parse combo information");
+        auto combo = jsonFindRequired (data, "combo", "cannot parse combo information");
+        auto defvalue = jsonFindRequired (data, "default", "cannot parse combo information");
 
         // add line feed just in case
         this->m_compiledContent += "\n";

--- a/src/WallpaperEngine/Render/Shaders/Compiler.cpp
+++ b/src/WallpaperEngine/Render/Shaders/Compiler.cpp
@@ -485,8 +485,8 @@ namespace WallpaperEngine::Render::Shaders
     void Compiler::parseComboConfiguration (const std::string& content)
     {
         json data = json::parse (content);
-        auto combo = jsonFindValueRequired(&data, "combo", "cannot parse combo information");
-        auto defvalue = jsonFindValueRequired(&data, "default", "cannot parse combo information");
+        auto combo = jsonFindRequired (&data, "combo", "cannot parse combo information");
+        auto defvalue = jsonFindRequired (&data, "default", "cannot parse combo information");
 
         // add line feed just in case
         this->m_compiledContent += "\n";

--- a/src/WallpaperEngine/Render/Shaders/Compiler.h
+++ b/src/WallpaperEngine/Render/Shaders/Compiler.h
@@ -4,7 +4,8 @@
 #include <iostream>
 #include <vector>
 #include <map>
-#include <nlohmann/json.hpp>
+
+#include "WallpaperEngine/Core/Core.h"
 
 #include "WallpaperEngine/FileSystem/FileSystem.h"
 


### PR DESCRIPTION
This PR adds a function `jsonFindRequired` in Core.cpp that is used for nlohmann::json.find that requires the key to be found.