### PR TITLE
Fixed issue #59 for Nvidia graphics cards and added compositor support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -160,6 +160,10 @@ int main (int argc, char* argv[])
     glfwWindowHint (GLFW_CONTEXT_VERSION_MAJOR, 2);
     glfwWindowHint (GLFW_CONTEXT_VERSION_MINOR, 1);
 
+    // will hide the window if we are drawing to X
+    if (!screens.empty())
+        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+
     auto containers = new WallpaperEngine::Assets::CCombinedContainer ();
 
     // update the used path with the full one

--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,11 @@
 #include <GL/glew.h>
 #include <GL/glx.h>
 #include <filesystem>
+#include <csignal>
 #include "GLFW/glfw3.h"
+
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
 
 #include "WallpaperEngine/Core/CProject.h"
 #include "WallpaperEngine/Render/CWallpaper.h"
@@ -52,6 +56,26 @@ std::string stringPathFixes(const std::string& s)
         str += '/';
 
     return std::move (str);
+}
+
+void free_display_wallpaper(int sig)
+{
+    Display* display = XOpenDisplay (nullptr);
+    Window root = DefaultRootWindow(display);
+    // create a blank pm to reset compositors values, compositors will render as a blank X window.
+    Pixmap pm = XCreatePixmap(display, root, 1, 1, 1);
+    Atom prop_root = XInternAtom(display, "_XROOTPMAP_ID", False);
+    Atom prop_esetroot = XInternAtom(display, "ESETROOT_PMAP_ID", False);
+    XChangeProperty(display, root, prop_root, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &pm, 1);
+    XChangeProperty(display, root, prop_esetroot, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &pm, 1);
+    XFreePixmap(display, pm);
+    // set background to black. Only needed if no compositors are running
+    XSetWindowBackground(display, root, 0);
+    // sync changes before exiting
+    XClearWindow(display, root);
+    XFlush(display);
+    XCloseDisplay(display);
+    exit(sig);
 }
 
 int main (int argc, char* argv[])
@@ -144,6 +168,14 @@ int main (int argc, char* argv[])
         throw std::runtime_error ("The specified path is not a folder");
 
     // ensure the path has a trailing slash
+
+    // Attach signals for unexpected killing of program by user. We need to reset the 
+    // screen otherwise the background will remain the last frame on sigterm or sigint.
+    if (!screens.empty())
+    {
+        std::signal(SIGINT, free_display_wallpaper);
+        std::signal(SIGTERM, free_display_wallpaper);
+    }
 
     // first of all, initialize the window
     if (glfwInit () == GLFW_FALSE)

--- a/src/WallpaperEngine/Render/CContext.cpp
+++ b/src/WallpaperEngine/Render/CContext.cpp
@@ -101,7 +101,10 @@ void CContext::render ()
         GC gc = XCreateGC(display, pm, 0, NULL);
         XFillRectangle(display, pm, gc, 0, 0, fullWidth, fullHeight);
 
-        char* image_data = this->m_wallpaper->renderImage ();
+        char* image_data;
+        image_data = new char[windowWidth*windowHeight*4];
+
+        this->m_wallpaper->render (this->m_defaultViewport, true, image_data);
         XImage* image = XCreateImage(display, CopyFromParent, 24, ZPixmap, 0, (char *)image_data, windowWidth, windowHeight, 32, 0);
         for (; cur != end; cur ++)
         {

--- a/src/WallpaperEngine/Render/CContext.cpp
+++ b/src/WallpaperEngine/Render/CContext.cpp
@@ -25,22 +25,19 @@ void CContext::initializeViewports ()
     if (this->m_isRootWindow == false || this->m_screens.empty () == true)
         return;
 
-    m_display = XOpenDisplay (nullptr);
+    Display* display = XOpenDisplay (nullptr);
 
     int xrandr_result, xrandr_error;
 
-    if (!XRRQueryExtension (m_display, &xrandr_result, &xrandr_error))
+    if (!XRRQueryExtension (display, &xrandr_result, &xrandr_error))
     {
         std::cerr << "XRandr is not present, cannot detect specified screens, running in window mode" << std::endl;
         return;
     }
 
-    int fullWidth = DisplayWidth (m_display, DefaultScreen (m_display));
-    int fullHeight = DisplayHeight (m_display, DefaultScreen (m_display));
-
-    m_pm = XCreatePixmap(m_display, DefaultRootWindow(m_display), fullWidth, fullHeight, 24);
-    m_gc = XCreateGC(m_display, m_pm, 0, NULL);
-    XRRScreenResources* screenResources = XRRGetScreenResources (m_display, DefaultRootWindow (m_display));
+    int fullWidth = DisplayWidth (display, DefaultScreen (display));
+    int fullHeight = DisplayHeight (display, DefaultScreen (display));
+    XRRScreenResources* screenResources = XRRGetScreenResources (display, DefaultRootWindow (display));
 
     // there are some situations where xrandr returns null (like screen not using the extension)
     if (screenResources == nullptr)
@@ -48,7 +45,7 @@ void CContext::initializeViewports ()
 
     for (int i = 0; i < screenResources->noutput; i ++)
     {
-        XRROutputInfo* info = XRRGetOutputInfo (m_display, screenResources, screenResources->outputs [i]);
+        XRROutputInfo* info = XRRGetOutputInfo (display, screenResources, screenResources->outputs [i]);
 
         // there are some situations where xrandr returns null (like screen not using the extension)
         if (info == nullptr)
@@ -61,7 +58,7 @@ void CContext::initializeViewports ()
         {
             if (info->connection == RR_Connected && strcmp (info->name, (*cur).c_str ()) == 0)
             {
-                XRRCrtcInfo* crtc = XRRGetCrtcInfo (m_display, screenResources, info->crtc);
+                XRRCrtcInfo* crtc = XRRGetCrtcInfo (display, screenResources, info->crtc);
 
                 std::cout << "Found requested screen: " << info->name << " -> " << crtc->x << "x" << crtc->y << ":" << crtc->width << "x" << crtc->height << std::endl;
 
@@ -81,7 +78,7 @@ void CContext::initializeViewports ()
     XRRFreeScreenResources (screenResources);
 
     // Cause of issue for issue #59 origial issue
-    // glfwWindowHintPointer (GLFW_NATIVE_PARENT_HANDLE, reinterpret_cast <void*> (DefaultRootWindow (m_display)));
+    // glfwWindowHintPointer (GLFW_NATIVE_PARENT_HANDLE, reinterpret_cast <void*> (DefaultRootWindow (display)));
 }
 
 void CContext::render ()
@@ -91,38 +88,43 @@ void CContext::render ()
 
     if (this->m_viewports.empty () == false)
     {
+        static Display* display = XOpenDisplay (nullptr);
         auto cur = this->m_viewports.begin ();
         auto end = this->m_viewports.end ();
 
-        Window root = DefaultRootWindow(m_display);
+        Window root = DefaultRootWindow(display);
         int windowWidth = 1920, windowHeight = 1080;
-        int fullWidth = DisplayWidth (m_display, DefaultScreen (m_display));
-        int fullHeight = DisplayHeight (m_display, DefaultScreen (m_display));
+        int fullWidth = DisplayWidth (display, DefaultScreen (display));
+        int fullHeight = DisplayHeight (display, DefaultScreen (display));
 
-        XFillRectangle(m_display, m_pm, m_gc, 0, 0, fullWidth, fullHeight);
+        Pixmap pm = XCreatePixmap(display, root, fullWidth, fullHeight, 24);
+        GC gc = XCreateGC(display, pm, 0, NULL);
+        XFillRectangle(display, pm, gc, 0, 0, fullWidth, fullHeight);
 
         char* image_data;
         image_data = new char[windowWidth*windowHeight*4];
 
         this->m_wallpaper->render (this->m_defaultViewport, true, image_data);
-        XImage* image = XCreateImage(m_display, CopyFromParent, 24, ZPixmap, 0, (char *)image_data, windowWidth, windowHeight, 32, 0);
+        XImage* image = XCreateImage(display, CopyFromParent, 24, ZPixmap, 0, (char *)image_data, windowWidth, windowHeight, 32, 0);
         for (; cur != end; cur ++)
         {
-            XPutImage(m_display, m_pm, m_gc, image, 0, 0, (*cur).x, (*cur).y, windowWidth, windowHeight);
+            XPutImage(display, pm, gc, image, 0, 0, (*cur).x, (*cur).y, windowWidth, windowHeight);
         }
 
         // _XROOTPMAP_ID & ESETROOT_PMAP_ID allow other programs (compositors) to 
         // edit the background. Without these, other programs will clear the screen.
-        Atom prop_root = XInternAtom(m_display, "_XROOTPMAP_ID", False);
-        Atom prop_esetroot = XInternAtom(m_display, "ESETROOT_PMAP_ID", False);
-        XChangeProperty(m_display, root, prop_root, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &m_pm, 1);
-        XChangeProperty(m_display, root, prop_esetroot, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &m_pm, 1);
+        Atom prop_root = XInternAtom(display, "_XROOTPMAP_ID", False);
+        Atom prop_esetroot = XInternAtom(display, "ESETROOT_PMAP_ID", False);
+        XChangeProperty(display, root, prop_root, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &pm, 1);
+        XChangeProperty(display, root, prop_esetroot, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &pm, 1);
 
-        XSetWindowBackgroundPixmap(m_display, root, m_pm);
-        XClearWindow(m_display, root);
-        XFlush(m_display);
+        XSetWindowBackgroundPixmap(display, root, pm);
+        XClearWindow(display, root);
+        XFlush(display);
 
         XDestroyImage(image);
+        XFreePixmap(display, pm);
+        XFreeGC(display, gc);
     }
     else
         this->m_wallpaper->render (this->m_defaultViewport);

--- a/src/WallpaperEngine/Render/CContext.cpp
+++ b/src/WallpaperEngine/Render/CContext.cpp
@@ -37,6 +37,9 @@ void CContext::initializeViewports ()
 
     int fullWidth = DisplayWidth (m_display, DefaultScreen (m_display));
     int fullHeight = DisplayHeight (m_display, DefaultScreen (m_display));
+
+    m_pm = XCreatePixmap(m_display, DefaultRootWindow(m_display), fullWidth, fullHeight, 24);
+    m_gc = XCreateGC(m_display, m_pm, 0, NULL);
     XRRScreenResources* screenResources = XRRGetScreenResources (m_display, DefaultRootWindow (m_display));
 
     // there are some situations where xrandr returns null (like screen not using the extension)
@@ -96,8 +99,6 @@ void CContext::render ()
         int fullWidth = DisplayWidth (m_display, DefaultScreen (m_display));
         int fullHeight = DisplayHeight (m_display, DefaultScreen (m_display));
 
-        m_pm = XCreatePixmap(m_display, root, fullWidth, fullHeight, 24);
-        m_gc = XCreateGC(m_display, m_pm, 0, NULL);
         XFillRectangle(m_display, m_pm, m_gc, 0, 0, fullWidth, fullHeight);
 
         char* image_data;

--- a/src/WallpaperEngine/Render/CContext.cpp
+++ b/src/WallpaperEngine/Render/CContext.cpp
@@ -89,8 +89,6 @@ void CContext::render ()
     if (this->m_viewports.empty () == false)
     {
         static Display* display = XOpenDisplay (nullptr);
-        bool firstFrame = true;
-        bool renderFrame = true;
         auto cur = this->m_viewports.begin ();
         auto end = this->m_viewports.end ();
 
@@ -103,7 +101,7 @@ void CContext::render ()
         GC gc = XCreateGC(display, pm, 0, NULL);
         XFillRectangle(display, pm, gc, 0, 0, fullWidth, fullHeight);
 
-        char* image_data = this->m_wallpaper->renderImage (*cur, renderFrame, firstFrame);
+        char* image_data = this->m_wallpaper->renderImage ();
         XImage* image = XCreateImage(display, CopyFromParent, 24, ZPixmap, 0, (char *)image_data, windowWidth, windowHeight, 32, 0);
         for (; cur != end; cur ++)
         {

--- a/src/WallpaperEngine/Render/CContext.cpp
+++ b/src/WallpaperEngine/Render/CContext.cpp
@@ -110,6 +110,13 @@ void CContext::render ()
             XPutImage(display, pm, gc, image, 0, 0, (*cur).x, (*cur).y, windowWidth, windowHeight);
         }
 
+        // _XROOTPMAP_ID & ESETROOT_PMAP_ID allow other programs (compositors) to 
+        // edit the background. Without these, other programs will clear the screen.
+        Atom prop_root = XInternAtom(display, "_XROOTPMAP_ID", False);
+        Atom prop_esetroot = XInternAtom(display, "ESETROOT_PMAP_ID", False);
+        XChangeProperty(display, root, prop_root, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &pm, 1);
+        XChangeProperty(display, root, prop_esetroot, XA_PIXMAP, 32, PropModeReplace, (unsigned char *) &pm, 1);
+
         XSetWindowBackgroundPixmap(display, root, pm);
         XClearWindow(display, root);
         XFlush(display);

--- a/src/WallpaperEngine/Render/CContext.h
+++ b/src/WallpaperEngine/Render/CContext.h
@@ -3,8 +3,6 @@
 #include <vector>
 #include <glm/vec4.hpp>
 
-#include <X11/Xlib.h>
-
 #include "WallpaperEngine/Input/CMouseInput.h"
 #include "CWallpaper.h"
 
@@ -32,8 +30,5 @@ namespace WallpaperEngine::Render
         CWallpaper* m_wallpaper;
         CMouseInput* m_mouse;
         bool m_isRootWindow;
-        Display* m_display;
-        Pixmap m_pm;
-        GC m_gc;
     };
 }

--- a/src/WallpaperEngine/Render/CContext.h
+++ b/src/WallpaperEngine/Render/CContext.h
@@ -3,6 +3,8 @@
 #include <vector>
 #include <glm/vec4.hpp>
 
+#include <X11/Xlib.h>
+
 #include "WallpaperEngine/Input/CMouseInput.h"
 #include "CWallpaper.h"
 
@@ -30,5 +32,8 @@ namespace WallpaperEngine::Render
         CWallpaper* m_wallpaper;
         CMouseInput* m_mouse;
         bool m_isRootWindow;
+        Display* m_display;
+        Pixmap m_pm;
+        GC m_gc;
     };
 }

--- a/src/WallpaperEngine/Render/CWallpaper.cpp
+++ b/src/WallpaperEngine/Render/CWallpaper.cpp
@@ -287,13 +287,14 @@ void CWallpaper::render (glm::vec4 viewport, bool renderFrame, bool newFrame)
     glDrawArrays (GL_TRIANGLES, 0, 6);
 }
 
-char* CWallpaper::renderImage (glm::vec4 viewport, bool renderFrame, bool newFrame)
+char* CWallpaper::renderImage ()
 {
-    if (renderFrame == true)
-        this->renderFrame (viewport);
-
     int windowWidth = 1920;
     int windowHeight = 1080;
+    glm::vec4 viewport = {0, 0, windowWidth, windowHeight};
+
+    this->renderFrame (viewport);
+
 
     if (this->getWallpaperData ()->is <WallpaperEngine::Core::CScene> ())
     {
@@ -380,8 +381,7 @@ char* CWallpaper::renderImage (glm::vec4 viewport, bool renderFrame, bool newFra
 
     glBindFramebuffer (GL_FRAMEBUFFER, screen_fbo->getFramebuffer());
 
-    if (newFrame == true)
-        glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glDisable (GL_BLEND);
     glDisable (GL_DEPTH_TEST);
     // do not use any shader

--- a/src/WallpaperEngine/Render/CWallpaper.cpp
+++ b/src/WallpaperEngine/Render/CWallpaper.cpp
@@ -185,116 +185,12 @@ void CWallpaper::setupShaders ()
     this->a_TexCoord = glGetAttribLocation (this->m_shader, "a_TexCoord");
 }
 
-void CWallpaper::render (glm::vec4 viewport, bool renderFrame, bool newFrame)
+void CWallpaper::render (glm::vec4 viewport, bool drawToBackground, char* image_data)
 {
-    if (renderFrame == true)
-        this->renderFrame (viewport);
-
-    int windowWidth = 1920;
-    int windowHeight = 1080;
-
-    if (this->getWallpaperData ()->is <WallpaperEngine::Core::CScene> ())
-    {
-        auto projection = this->getWallpaperData ()->as <WallpaperEngine::Core::CScene> ()->getOrthogonalProjection ();
-
-        windowWidth = projection->getWidth ();
-        windowHeight = projection->getHeight ();
-    }
-    else if (this->is <WallpaperEngine::Render::CVideo> ())
-    {
-        auto video = this->as <WallpaperEngine::Render::CVideo> ();
-
-        windowWidth = video->getWidth ();
-        windowHeight = video->getHeight ();
-    }
-
-    float widthRatio = windowWidth / viewport.z;
-    float heightRatio = windowHeight / viewport.w;
-
-    if (widthRatio > 1.0f)
-    {
-        float diff = widthRatio - 1.0f;
-
-        widthRatio -= diff;
-        heightRatio -= diff;
-    }
-
-    if (heightRatio > 1.0f)
-    {
-        float diff = heightRatio - 1.0f;
-
-        widthRatio -= diff;
-        heightRatio -= diff;
-    }
-
-    if (widthRatio < 1.0f)
-    {
-        float diff = 1.0f - widthRatio;
-
-        widthRatio += diff;
-        heightRatio += diff;
-    }
-
-    if (heightRatio < 1.0f)
-    {
-        float diff = 1.0f - heightRatio;
-
-        widthRatio += diff;
-        heightRatio += diff;
-    }
-
-    if (widthRatio < 0.0f) widthRatio = -widthRatio;
-    if (heightRatio < 0.0f) heightRatio = -heightRatio;
-
-    GLfloat position [] = {
-        -widthRatio, -heightRatio, 0.0f,
-        widthRatio, -heightRatio, 0.0f,
-        -widthRatio, heightRatio, 0.0f,
-        -widthRatio, heightRatio, 0.0f,
-        widthRatio, -heightRatio, 0.0f,
-        widthRatio, heightRatio, 0.0f
-    };
-
-    glBindBuffer (GL_ARRAY_BUFFER, this->m_positionBuffer);
-    glBufferData (GL_ARRAY_BUFFER, sizeof (position), position, GL_STATIC_DRAW);
-
-    glViewport (viewport.x, viewport.y, viewport.z, viewport.w);
-
-    // write to default's framebuffer
-    glBindFramebuffer (GL_FRAMEBUFFER, GL_NONE);
-
-    if (newFrame == true)
-        glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glDisable (GL_BLEND);
-    glDisable (GL_DEPTH_TEST);
-    // do not use any shader
-    glUseProgram (this->m_shader);
-    // activate scene texture
-    glActiveTexture (GL_TEXTURE0);
-    glBindTexture (GL_TEXTURE_2D, this->getWallpaperTexture ());
-    // set uniforms and attribs
-    glEnableVertexAttribArray (this->a_TexCoord);
-    glBindBuffer (GL_ARRAY_BUFFER, this->m_texCoordBuffer);
-    glVertexAttribPointer (this->a_TexCoord, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
-
-    glEnableVertexAttribArray (this->a_Position);
-    glBindBuffer (GL_ARRAY_BUFFER, this->m_positionBuffer);
-    glVertexAttribPointer (this->a_Position, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
-
-    glUniform1i (this->g_Texture0, 0);
-    // write the framebuffer as is to the screen
-    glBindBuffer (GL_ARRAY_BUFFER, this->m_texCoordBuffer);
-    glDrawArrays (GL_TRIANGLES, 0, 6);
-}
-
-char* CWallpaper::renderImage ()
-{
-    int windowWidth = 1920;
-    int windowHeight = 1080;
-    glm::vec4 viewport = {0, 0, windowWidth, windowHeight};
-
     this->renderFrame (viewport);
 
+    int windowWidth = 1920;
+    int windowHeight = 1080;
 
     if (this->getWallpaperData ()->is <WallpaperEngine::Core::CScene> ())
     {
@@ -361,26 +257,52 @@ char* CWallpaper::renderImage ()
     glBindBuffer (GL_ARRAY_BUFFER, this->m_positionBuffer);
     glBufferData (GL_ARRAY_BUFFER, sizeof (position), position, GL_STATIC_DRAW);
 
-    // Need to flip the image (FB stores the image upside down)
-    GLfloat texCoords [] = {
-        0.0f, 1.0f,
-        1.0f, 1.0f,
-        0.0f, 0.0f,
-        0.0f, 0.0f,
-        1.0f, 1.0f,
-        1.0f, 0.0f
-    };
-
-    glBindBuffer (GL_ARRAY_BUFFER, this->m_texCoordBuffer);
-    glBufferData (GL_ARRAY_BUFFER, sizeof (texCoords), texCoords, GL_STATIC_DRAW);
+    // we only want texCoords to be set once
+    static bool setTexCoords = true;
+    if (setTexCoords)
+    {
+        setTexCoords = false;
+        if (drawToBackground)
+        {
+            // Need to flip the image (FB stores the image upside down)
+            GLfloat texCoords [] = {
+                0.0f, 1.0f,
+                1.0f, 1.0f,
+                0.0f, 0.0f,
+                0.0f, 0.0f,
+                1.0f, 1.0f,
+                1.0f, 0.0f
+            };
+            glBindBuffer (GL_ARRAY_BUFFER, this->m_texCoordBuffer);
+            glBufferData (GL_ARRAY_BUFFER, sizeof (texCoords), texCoords, GL_STATIC_DRAW);
+        }
+        else 
+        {
+            GLfloat texCoords [] = {
+                0.0f, 0.0f,
+                1.0f, 0.0f,
+                0.0f, 1.0f,
+                0.0f, 1.0f,
+                1.0f, 0.0f,
+                1.0f, 1.0f
+            };
+            glBindBuffer (GL_ARRAY_BUFFER, this->m_texCoordBuffer);
+            glBufferData (GL_ARRAY_BUFFER, sizeof (texCoords), texCoords, GL_STATIC_DRAW);
+        }
+    }
 
     glViewport (viewport.x, viewport.y, viewport.z, viewport.w);
 
-    // A fbo for flipping the image. Without this call the image will be flipped.
-    static CFBO* screen_fbo = this->createFBO ("_sc_FullFrameBuffer", ITexture::TextureFormat::ARGB8888, 1.0, windowWidth, windowHeight, windowWidth, windowHeight);
+    static CFBO* screen_fbo = new CFBO("_sc_FullFrameBuffer", ITexture::TextureFormat::ARGB8888, 1.0, windowWidth, windowHeight, windowWidth, windowHeight);
+    
+    if (drawToBackground)
+        // write to screen buffer
+        glBindFramebuffer (GL_FRAMEBUFFER, screen_fbo->getFramebuffer());
+    else
+        // write to default's framebuffer
+        glBindFramebuffer (GL_FRAMEBUFFER, GL_NONE);
 
-    glBindFramebuffer (GL_FRAMEBUFFER, screen_fbo->getFramebuffer());
-
+    
     glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glDisable (GL_BLEND);
     glDisable (GL_DEPTH_TEST);
@@ -403,13 +325,9 @@ char* CWallpaper::renderImage ()
     glBindBuffer (GL_ARRAY_BUFFER, this->m_texCoordBuffer);
     glDrawArrays (GL_TRIANGLES, 0, 6);
 
-    glBindTexture (GL_TEXTURE_2D, screen_fbo->getTextureID ());
-
     // Get FB data from OpenGL, X11 will free this pointer when it is created into an XImage.
-    char* image;
-    image = (char*)malloc(windowWidth*windowHeight*4);
-    glReadPixels(0, 0, 1920, 1080, GL_BGRA,  GL_UNSIGNED_BYTE, (void*)(image));
-    return image;
+    if (image_data)
+        glReadPixels(0, 0, 1920, 1080, GL_BGRA,  GL_UNSIGNED_BYTE, (void*)(image_data));
 }
 
 void CWallpaper::setupFramebuffers ()

--- a/src/WallpaperEngine/Render/CWallpaper.h
+++ b/src/WallpaperEngine/Render/CWallpaper.h
@@ -36,8 +36,8 @@ namespace WallpaperEngine::Render
         /**
          * Performs a render pass of the wallpaper and returns the char* of the image
          */
-        char* renderImage (glm::vec4 viewport, bool renderFrame = true, bool newFrame = true);
-        
+        char* renderImage ();
+
         /**
          * @return The container to resolve files for this wallpaper
          */

--- a/src/WallpaperEngine/Render/CWallpaper.h
+++ b/src/WallpaperEngine/Render/CWallpaper.h
@@ -34,6 +34,11 @@ namespace WallpaperEngine::Render
         void render (glm::vec4 viewport, bool renderFrame = true, bool newFrame = true);
 
         /**
+         * Performs a render pass of the wallpaper and returns the char* of the image
+         */
+        char* renderImage (glm::vec4 viewport, bool renderFrame = true, bool newFrame = true);
+        
+        /**
          * @return The container to resolve files for this wallpaper
          */
         CContainer* getContainer () const;

--- a/src/WallpaperEngine/Render/CWallpaper.h
+++ b/src/WallpaperEngine/Render/CWallpaper.h
@@ -31,12 +31,7 @@ namespace WallpaperEngine::Render
         /**
          * Performs a render pass of the wallpaper
          */
-        void render (glm::vec4 viewport, bool renderFrame = true, bool newFrame = true);
-
-        /**
-         * Performs a render pass of the wallpaper and returns the char* of the image
-         */
-        char* renderImage ();
+        void render (glm::vec4 viewport, bool drawToBackground = false, char* image_data = nullptr);
 
         /**
          * @return The container to resolve files for this wallpaper


### PR DESCRIPTION
The issue was caused by a call to add the root window to GLFW_NATIVE_PARENT_HANDLE in GLFW. I don't fully understand why it results in a crash but something with the nvidia drivers must cause it. Removing it resulted in me needing to create a different way to render to the screen so I just used X11 functions to do it more safely. A result of doing this allowed me to use flags that compositors use so now you can use picom and the like. I had to add some signal handling to clear the last frame from memory, otherwise it just exist forever after the program exits by user interruption.

I have tested this on a Nvidia 2070 and on a laptop with a Intel i3 with UHD Graphics.

![screenshot](https://user-images.githubusercontent.com/70032726/155825412-927338ec-e23f-42e4-9754-6a58eceedb06.png)
