### PR TITLE
Window class, x, y, width and height arguements

### DIFF
--- a/src/WallpaperEngine/Application/CApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/CApplicationContext.cpp
@@ -24,6 +24,7 @@ struct option long_options [] = {
     {"screenshot",      required_argument, nullptr, 'c'},
     {"list-properties", no_argument,       nullptr, 'l'},
     {"set-property",    required_argument, nullptr, 'o'},
+    {"class",           required_argument, nullptr, 'x'},
     {nullptr,                           0, nullptr,   0}
 };
 
@@ -48,7 +49,8 @@ CApplicationContext::CApplicationContext (int argc, char* argv[]) :
     maximumFPS (30),
     audioVolume (128),
     audioEnabled (true),
-    onlyListProperties (false)
+    onlyListProperties (false),
+    window_class (""),
 {
     int c;
 
@@ -109,6 +111,10 @@ CApplicationContext::CApplicationContext (int argc, char* argv[]) :
             case 'c':
                 this->takeScreenshot = true;
                 this->screenshot = stringPathFixes (optarg);
+                break;
+
+            case 'x':
+                this->window_class = optarg;
                 break;
         }
     }
@@ -196,4 +202,5 @@ void CApplicationContext::printHelp (const char* route)
     sLog.out ("\t--screenshot\t\t\t\tTakes a screenshot of the background");
     sLog.out ("\t--list-properties\t\t\tList all the available properties and their possible values");
     sLog.out ("\t--set-property <name=value>\tOverrides the default value of the given property");
+    sLog.out ("\t--class <class name>\t\t\tSets X11 window class");
 }

--- a/src/WallpaperEngine/Application/CApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/CApplicationContext.cpp
@@ -25,6 +25,8 @@ struct option long_options [] = {
     {"list-properties", no_argument,       nullptr, 'l'},
     {"set-property",    required_argument, nullptr, 'o'},
     {"class",           required_argument, nullptr, 'x'},
+    {"width",           required_argument, nullptr, 'w'},
+    {"height",          required_argument, nullptr, 't'},
     {nullptr,                           0, nullptr,   0}
 };
 
@@ -51,6 +53,8 @@ CApplicationContext::CApplicationContext (int argc, char* argv[]) :
     audioEnabled (true),
     onlyListProperties (false),
     window_class (""),
+    window_width(1280),
+    window_height(720)
 {
     int c;
 
@@ -115,6 +119,13 @@ CApplicationContext::CApplicationContext (int argc, char* argv[]) :
 
             case 'x':
                 this->window_class = optarg;
+                break;
+            case 'w':
+                this->window_width = atoi(optarg);
+                break;
+
+            case 't':
+                this->window_height = atoi(optarg);
                 break;
         }
     }
@@ -203,4 +214,6 @@ void CApplicationContext::printHelp (const char* route)
     sLog.out ("\t--list-properties\t\t\tList all the available properties and their possible values");
     sLog.out ("\t--set-property <name=value>\tOverrides the default value of the given property");
     sLog.out ("\t--class <class name>\t\t\tSets X11 window class");
+    sLog.out ("\t--width <width>\t\t\tSets the window width");
+    sLog.out ("\t--height <height>\t\t\tSets the window height");
 }

--- a/src/WallpaperEngine/Application/CApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/CApplicationContext.cpp
@@ -25,6 +25,8 @@ struct option long_options [] = {
     {"list-properties", no_argument,       nullptr, 'l'},
     {"set-property",    required_argument, nullptr, 'o'},
     {"class",           required_argument, nullptr, 'x'},
+    {"x",               required_argument, nullptr, 'z'},
+    {"y",               required_argument, nullptr, 'y'},
     {"width",           required_argument, nullptr, 'w'},
     {"height",          required_argument, nullptr, 't'},
     {nullptr,                           0, nullptr,   0}
@@ -53,6 +55,8 @@ CApplicationContext::CApplicationContext (int argc, char* argv[]) :
     audioEnabled (true),
     onlyListProperties (false),
     window_class (""),
+    window_pos_x(0),
+    window_pos_y(0),
     window_width(1280),
     window_height(720)
 {
@@ -120,6 +124,15 @@ CApplicationContext::CApplicationContext (int argc, char* argv[]) :
             case 'x':
                 this->window_class = optarg;
                 break;
+
+            case 'z':
+                this->window_pos_x = atoi(optarg);
+                break;
+
+            case 'y':
+                this->window_pos_y = atoi(optarg);
+                break;
+
             case 'w':
                 this->window_width = atoi(optarg);
                 break;
@@ -214,6 +227,8 @@ void CApplicationContext::printHelp (const char* route)
     sLog.out ("\t--list-properties\t\t\tList all the available properties and their possible values");
     sLog.out ("\t--set-property <name=value>\tOverrides the default value of the given property");
     sLog.out ("\t--class <class name>\t\t\tSets X11 window class");
+    sLog.out ("\t--x <x>\t\t\tSets the window x pos");
+    sLog.out ("\t--y <y>\t\t\tSets the window y pos");
     sLog.out ("\t--width <width>\t\t\tSets the window width");
     sLog.out ("\t--height <height>\t\t\tSets the window height");
 }

--- a/src/WallpaperEngine/Application/CApplicationContext.h
+++ b/src/WallpaperEngine/Application/CApplicationContext.h
@@ -25,6 +25,8 @@ namespace WallpaperEngine::Application
         bool onlyListProperties;
         FREE_IMAGE_FORMAT screenshotFormat;
         std::string window_class;
+        int window_width;
+        int window_height;
 
     private:
         void validatePath ();

--- a/src/WallpaperEngine/Application/CApplicationContext.h
+++ b/src/WallpaperEngine/Application/CApplicationContext.h
@@ -24,6 +24,7 @@ namespace WallpaperEngine::Application
         bool audioEnabled;
         bool onlyListProperties;
         FREE_IMAGE_FORMAT screenshotFormat;
+        std::string window_class;
 
     private:
         void validatePath ();

--- a/src/WallpaperEngine/Application/CApplicationContext.h
+++ b/src/WallpaperEngine/Application/CApplicationContext.h
@@ -25,6 +25,8 @@ namespace WallpaperEngine::Application
         bool onlyListProperties;
         FREE_IMAGE_FORMAT screenshotFormat;
         std::string window_class;
+        int window_pos_x;
+        int window_pos_y;
         int window_width;
         int window_height;
 

--- a/src/WallpaperEngine/Application/CWallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/CWallpaperApplication.cpp
@@ -273,3 +273,8 @@ void CWallpaperApplication::signal (int signal)
 {
     g_KeepRunning = false;
 }
+
+const CApplicationContext& CWallpaperApplication::get_context () const
+{
+    return this->m_context;
+}

--- a/src/WallpaperEngine/Application/CWallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/CWallpaperApplication.cpp
@@ -222,7 +222,7 @@ void CWallpaperApplication::show ()
     // initialize audio context
     WallpaperEngine::Audio::CAudioContext audioContext (audioDriver);
     // initialize OpenGL driver
-    WallpaperEngine::Render::Drivers::COpenGLDriver videoDriver (this->m_project->getTitle ().c_str ());
+    WallpaperEngine::Render::Drivers::COpenGLDriver videoDriver (this->m_project->getTitle ().c_str (), this->m_context);
     // initialize the input subsystem
     WallpaperEngine::Input::CInputContext inputContext (videoDriver);
     // initialize render context

--- a/src/WallpaperEngine/Application/CWallpaperApplication.h
+++ b/src/WallpaperEngine/Application/CWallpaperApplication.h
@@ -22,6 +22,7 @@ namespace WallpaperEngine::Application
 
         void show ();
         void signal (int signal);
+        const CApplicationContext& get_context () const;
 
     private:
         void setupContainer ();

--- a/src/WallpaperEngine/Render/CRenderContext.cpp
+++ b/src/WallpaperEngine/Render/CRenderContext.cpp
@@ -80,6 +80,7 @@ void CRenderContext::setupWindow ()
 {
     this->m_driver.showWindow ();
     this->m_driver.resizeWindow ({this->m_app.get_context().window_width, this->m_app.get_context().window_height});
+    this->m_driver.reposWindow({this->m_app.get_context().window_pos_x, this->m_app.get_context().window_pos_y});
 }
 
 void CRenderContext::setupScreens ()

--- a/src/WallpaperEngine/Render/CRenderContext.cpp
+++ b/src/WallpaperEngine/Render/CRenderContext.cpp
@@ -12,8 +12,6 @@
 #include "CRenderContext.h"
 #include "CVideo.h"
 
-#define DEFAULT_WINDOW_WIDTH 1280
-#define DEFAULT_WINDOW_HEIGHT 720
 
 using namespace WallpaperEngine::Render;
 
@@ -81,7 +79,7 @@ void CRenderContext::initialize ()
 void CRenderContext::setupWindow ()
 {
     this->m_driver.showWindow ();
-    this->m_driver.resizeWindow ({DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT});
+    this->m_driver.resizeWindow ({this->m_app.get_context().window_width, this->m_app.get_context().window_height});
 }
 
 void CRenderContext::setupScreens ()

--- a/src/WallpaperEngine/Render/Drivers/COpenGLDriver.cpp
+++ b/src/WallpaperEngine/Render/Drivers/COpenGLDriver.cpp
@@ -4,7 +4,7 @@
 
 using namespace WallpaperEngine::Render::Drivers;
 
-COpenGLDriver::COpenGLDriver (const char* windowTitle) :
+COpenGLDriver::COpenGLDriver (const char* windowTitle, CApplicationContext& m_context) :
     m_frameCounter (0)
 {
     // initialize glfw
@@ -21,6 +21,9 @@ COpenGLDriver::COpenGLDriver (const char* windowTitle) :
 #if !NDEBUG
 	glfwWindowHint (GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
 #endif /* DEBUG */
+
+    if (!m_context.window_class.empty())
+        windowTitle = m_context.window_class.c_str();
 
     // create window, size doesn't matter as long as we don't show it
     this->m_window = glfwCreateWindow (640, 480, windowTitle, nullptr, nullptr);

--- a/src/WallpaperEngine/Render/Drivers/COpenGLDriver.cpp
+++ b/src/WallpaperEngine/Render/Drivers/COpenGLDriver.cpp
@@ -60,6 +60,11 @@ bool COpenGLDriver::closeRequested ()
     return glfwWindowShouldClose (this->m_window);
 }
 
+void COpenGLDriver::reposWindow (glm::ivec2 pos)
+{
+    glfwSetWindowPos (this->m_window, pos.x, pos.y);
+}
+
 void COpenGLDriver::resizeWindow (glm::ivec2 size)
 {
     glfwSetWindowSize (this->m_window, size.x, size.y);

--- a/src/WallpaperEngine/Render/Drivers/COpenGLDriver.h
+++ b/src/WallpaperEngine/Render/Drivers/COpenGLDriver.h
@@ -21,6 +21,7 @@ namespace WallpaperEngine::Render::Drivers
 
         float getRenderTime () override;
         bool closeRequested () override;
+        void reposWindow (glm::ivec2 size) override;
         void resizeWindow (glm::ivec2 size) override;
         void showWindow () override;
         void hideWindow () override;

--- a/src/WallpaperEngine/Render/Drivers/COpenGLDriver.h
+++ b/src/WallpaperEngine/Render/Drivers/COpenGLDriver.h
@@ -3,13 +3,20 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 #include "WallpaperEngine/Render/Drivers/CVideoDriver.h"
+#include "WallpaperEngine/Application/CApplicationContext.h"
+
+using namespace WallpaperEngine::Application;
+namespace WallpaperEngine::Application
+{
+    class CWallpaperApplication;
+}
 
 namespace WallpaperEngine::Render::Drivers
 {
     class COpenGLDriver : public CVideoDriver
     {
     public:
-        explicit COpenGLDriver (const char* windowTitle);
+        explicit COpenGLDriver (const char* windowTitle, CApplicationContext& m_context);
         ~COpenGLDriver();
 
         float getRenderTime () override;

--- a/src/WallpaperEngine/Render/Drivers/CVideoDriver.h
+++ b/src/WallpaperEngine/Render/Drivers/CVideoDriver.h
@@ -9,6 +9,7 @@ namespace WallpaperEngine::Render::Drivers
     public:
         virtual float getRenderTime () = 0;
         virtual bool closeRequested () = 0;
+        virtual void reposWindow (glm::ivec2 size) = 0;
         virtual void resizeWindow (glm::ivec2 size) = 0;
         virtual void showWindow () = 0;
         virtual void hideWindow () = 0;


### PR DESCRIPTION
You might want to change some code, but that's the general idea.
More info at https://github.com/Almamu/linux-wallpaperengine/discussions/146

It could be also interesting to add options to set some x11 hints, like make it appear below other clients, set it to sticky, make it non moveable/resizeable, set skip taskbar hint etc. Right now I apply these props to the client via my awesome config, but it could be useful for other WMs where you can't do such thing