### PR TITLE
Fix crash when 2+ screens are connected, but not all are active when running in X11 mode.

### DIFF
--- a/src/WallpaperEngine/Render/Drivers/Detectors/CX11FullScreenDetector.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Detectors/CX11FullScreenDetector.cpp
@@ -155,6 +155,9 @@ namespace WallpaperEngine::Render::Drivers::Detectors
 
             XRRCrtcInfo* crtc = XRRGetCrtcInfo (this->m_display, screenResources, info->crtc);
 
+	    if (crtc == nullptr)
+		    continue;
+
             // add the screen to the list of screens
             this->m_screens.push_back (
                 {

--- a/src/WallpaperEngine/Render/Drivers/Detectors/CX11FullScreenDetector.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Detectors/CX11FullScreenDetector.cpp
@@ -155,6 +155,7 @@ namespace WallpaperEngine::Render::Drivers::Detectors
 
             XRRCrtcInfo* crtc = XRRGetCrtcInfo (this->m_display, screenResources, info->crtc);
 
+	    // screen not active, ignore it
 	    if (crtc == nullptr)
 		    continue;
 

--- a/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
@@ -167,10 +167,20 @@ void CX11Output::loadScreenInfo ()
 
     XRRFreeScreenResources (screenResources);
 
-    // Check if all screens from --screen-root are actually screens
-    if (this->m_viewports.size() != this->m_context.settings.general.screenBackgrounds.size()) {
-	    sLog.exception("Some outputs could not be initialized, please check parameters and try again");
+    bool any = false;
+
+    for (auto& o : this->m_screens)
+    {
+        const auto cur = this->m_context.settings.general.screenBackgrounds.find (o->name);
+
+        if (cur == this->m_context.settings.general.screenBackgrounds.end ())
+            continue;
+
+        any = true;
     }
+
+    if (!any)
+        sLog.exception("No outputs could be initialized, please check the parameters and try again");
 
     // create pixmap so we can draw things in there
     this->m_pixmap = XCreatePixmap (this->m_display, this->m_root, this->m_fullWidth, this->m_fullHeight, 24);

--- a/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
@@ -136,6 +136,7 @@ void CX11Output::loadScreenInfo ()
 
         XRRCrtcInfo* crtc = XRRGetCrtcInfo (this->m_display, screenResources, info->crtc);
 
+	// screen not active, ignore it
 	if (crtc == nullptr)
 		continue;
 

--- a/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
@@ -169,7 +169,7 @@ void CX11Output::loadScreenInfo ()
 
     // Check if all screens from --screen-root are actually screens
     if (this->m_viewports.size() != this->m_context.settings.general.screenBackgrounds.size()) {
-	    sLog.exception("Invalid screen in arguments.");
+	    sLog.exception("Some outputs could not be initialized, please check parameters and try again");
     }
 
     // create pixmap so we can draw things in there

--- a/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
@@ -167,6 +167,11 @@ void CX11Output::loadScreenInfo ()
 
     XRRFreeScreenResources (screenResources);
 
+    // Check if all screens from --screen-root are actually screens
+    if (this->m_viewports.size() != this->m_context.settings.general.screenBackgrounds.size()) {
+	    sLog.exception("Invalid screen in arguments.");
+    }
+
     // create pixmap so we can draw things in there
     this->m_pixmap = XCreatePixmap (this->m_display, this->m_root, this->m_fullWidth, this->m_fullHeight, 24);
     this->m_gc = XCreateGC (this->m_display, this->m_pixmap, 0, nullptr);

--- a/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/CX11Output.cpp
@@ -136,6 +136,9 @@ void CX11Output::loadScreenInfo ()
 
         XRRCrtcInfo* crtc = XRRGetCrtcInfo (this->m_display, screenResources, info->crtc);
 
+	if (crtc == nullptr)
+		continue;
+
         // add the screen to the list of screens
         this->m_screens.push_back (
             new CX11OutputViewport


### PR DESCRIPTION
When not all connected screens are active XRRGetCrtcInfo returns NULL for the inactive screens resulting in a SIGSEGV when trying to push it to the screens vector.

TODO:
---
- [x] When user sets --screen-root to a non-existent screen, program still runs without fatal error.
- [x] Maybe this can be checked in the same if statement as the connection check?
  - **No.** There is a way in XRandr to get only active monitors, but that involves manually creating requests and internal Xorg functions. See [this](https://gitlab.freedesktop.org/xorg/app/xrandr/-/blob/master/xrandr.c#L2571) and [this](https://gitlab.freedesktop.org/xorg/lib/libxrandr/-/blob/master/src/XrrMonitor.c#L58)
- [x] Is this also a problem on Wayland? **No.**