### PR TITLE
Fixed texture clamping caused by texture coordinates being outside of (0,1) interval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,8 @@ add_executable(
 
     src/WallpaperEngine/Render/CWallpaper.h
     src/WallpaperEngine/Render/CWallpaper.cpp
+    src/WallpaperEngine/Render/CWallpaperState.h
+    src/WallpaperEngine/Render/CWallpaperState.cpp
     src/WallpaperEngine/Render/CScene.h
     src/WallpaperEngine/Render/CScene.cpp
     src/WallpaperEngine/Render/CVideo.h

--- a/src/WallpaperEngine/Application/CApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/CApplicationContext.cpp
@@ -28,6 +28,7 @@ struct option long_options[] = {
     { "noautomute", no_argument,            nullptr, 'm' },
     { "no-fullscreen-pause", no_argument,   nullptr, 'n' },
     { "disable-mouse", no_argument,         nullptr, 'e' },
+    { "clamp-strategy", required_argument,  nullptr, 't' },
     { nullptr, 0,                           nullptr, 0 }
 };
 
@@ -65,7 +66,7 @@ CApplicationContext::CApplicationContext (int argc, char* argv[])
             .mode = NORMAL_WINDOW,
             .maximumFPS = 30,
             .pauseOnFullscreen = true,
-            .window = { .geometry = {}},
+            .window = { .geometry = {}, .clamp = WallpaperEngine::Assets::ITexture::TextureFlags::ClampUVs, .scaleToFit=false },
         },
         .audio =
         {
@@ -89,7 +90,7 @@ CApplicationContext::CApplicationContext (int argc, char* argv[])
 
     std::string lastScreen;
 
-    while ((c = getopt_long (argc, argv, "b:r:p:d:shf:a:w:mn", long_options, nullptr)) != -1)
+    while ((c = getopt_long (argc, argv, "b:r:p:d:shf:a:w:mnt:", long_options, nullptr)) != -1)
     {
         switch (c)
         {
@@ -194,6 +195,29 @@ CApplicationContext::CApplicationContext (int argc, char* argv[])
                 this->settings.mouse.enabled = false;
                 break;
 
+            case 't':
+            {
+                char opt = optarg[0];
+                switch (opt)
+                {
+                case 's':/* stretch*/
+                    this->settings.render.window.scaleToFit=true;
+                    break;
+                case 'b':/* clamp border (crop black)*/
+                    this->settings.render.window.clamp = WallpaperEngine::Assets::ITexture::TextureFlags::ClampUVsBorder;//clampStrategy(optarg);
+                    break;
+                case 'c':/* clamp*/
+                    this->settings.render.window.clamp = WallpaperEngine::Assets::ITexture::TextureFlags::ClampUVs;
+                    break;
+                case 'r':
+                    this->settings.render.window.clamp = WallpaperEngine::Assets::ITexture::TextureFlags::NoFlags;
+                    break;
+                default:
+                    sLog.error("Wrong argument provided for clamp-strategy");
+                    break;
+                }
+            }
+            break;
             default:
                 sLog.out ("Default on path parsing: ", optarg);
                 break;
@@ -290,4 +314,5 @@ void CApplicationContext::printHelp (const char* route)
     sLog.out ("\t--set-property <name=value>\tOverrides the default value of the given property");
     sLog.out ("\t--no-fullscreen-pause\tPrevents the background pausing when an app is fullscreen");
     sLog.out ("\t--disable-mouse\tDisables mouse interactions");
+    sLog.out ("\t--clamp-strategy <strategy>\t Clamp strategy if wallpaper doesn't fit screen. Can be stretch, border, repeat, clamp. Can be shortend to s, b, r, c. Default is clamp");
 }

--- a/src/WallpaperEngine/Application/CApplicationContext.h
+++ b/src/WallpaperEngine/Application/CApplicationContext.h
@@ -12,6 +12,7 @@
 #include "CApplicationState.h"
 
 #include "WallpaperEngine/Assets/ITexture.h"
+#include "WallpaperEngine/Render/CWallpaperState.h"
 
 namespace WallpaperEngine::Application
 {
@@ -52,6 +53,8 @@ namespace WallpaperEngine::Application
                 std::map <std::string, std::filesystem::path> screenBackgrounds;
                 /** Properties to change values for */
                 std::map <std::string, std::string> properties;
+                /** The scaling mode for different screens */
+                std::map <std::string, WallpaperEngine::Render::CWallpaperState::TextureUVsScaling> screenScalings;
             } general;
 
             /**
@@ -71,7 +74,7 @@ namespace WallpaperEngine::Application
                     /** The window size used in explicit window */
                     glm::ivec4 geometry;
                     WallpaperEngine::Assets::ITexture::TextureFlags clamp;
-                    bool scaleToFit;
+                    WallpaperEngine::Render::CWallpaperState::TextureUVsScaling scalingMode;
                 } window;
             } render;
 

--- a/src/WallpaperEngine/Application/CApplicationContext.h
+++ b/src/WallpaperEngine/Application/CApplicationContext.h
@@ -11,6 +11,8 @@
 
 #include "CApplicationState.h"
 
+#include "WallpaperEngine/Assets/ITexture.h"
+
 namespace WallpaperEngine::Application
 {
 	/**
@@ -68,6 +70,8 @@ namespace WallpaperEngine::Application
                 {
                     /** The window size used in explicit window */
                     glm::ivec4 geometry;
+                    WallpaperEngine::Assets::ITexture::TextureFlags clamp;
+                    bool scaleToFit;
                 } window;
             } render;
 

--- a/src/WallpaperEngine/Application/CWallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/CWallpaperApplication.cpp
@@ -322,13 +322,13 @@ namespace WallpaperEngine::Application
         for (const auto& it : this->m_backgrounds)
             context->setWallpaper (
                 it.first,
-                WallpaperEngine::Render::CWallpaper::fromWallpaper (it.second->getWallpaper (), *context, *audioContext)
+                WallpaperEngine::Render::CWallpaper::fromWallpaper (it.second->getWallpaper (), *context, *audioContext, this->m_context.settings.general.screenScalings[it.first])
             );
 
         // set the default rendering wallpaper if available
         if (this->m_defaultBackground != nullptr)
             context->setDefaultWallpaper (WallpaperEngine::Render::CWallpaper::fromWallpaper (
-                this->m_defaultBackground->getWallpaper (), *context, *audioContext
+                this->m_defaultBackground->getWallpaper (), *context, *audioContext, this->m_context.settings.render.window.scalingMode
             ));
 
         static time_t seconds;

--- a/src/WallpaperEngine/Assets/ITexture.h
+++ b/src/WallpaperEngine/Assets/ITexture.h
@@ -69,6 +69,7 @@ namespace WallpaperEngine::Assets
             NoInterpolation = 1,
             ClampUVs = 2,
             IsGif = 4,
+            ClampUVsBorder = 8,
         };
 
         /**

--- a/src/WallpaperEngine/Render/CFBO.cpp
+++ b/src/WallpaperEngine/Render/CFBO.cpp
@@ -41,6 +41,11 @@ CFBO::CFBO (
         glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     }
+    else if (flags & TextureFlags::ClampUVsBorder)
+    {
+        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    }
     else
     {
         glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/src/WallpaperEngine/Render/CRenderContext.cpp
+++ b/src/WallpaperEngine/Render/CRenderContext.cpp
@@ -36,9 +36,9 @@ namespace WallpaperEngine::Render
 
         // render the background
         if (ref != this->m_wallpapers.end ())
-            ref->second->render (viewport->viewport, this->getOutput ().renderVFlip ());
+            ref->second->render (viewport->viewport, this->getOutput ().renderVFlip (), this->getApp().getContext().settings.render.window.scaleToFit);
         else
-            this->m_defaultWallpaper->render (viewport->viewport, this->getOutput ().renderVFlip ());
+            this->m_defaultWallpaper->render (viewport->viewport, this->getOutput ().renderVFlip (), this->getApp().getContext().settings.render.window.scaleToFit);
 
 #if !NDEBUG
         glPopDebugGroup ();

--- a/src/WallpaperEngine/Render/CRenderContext.cpp
+++ b/src/WallpaperEngine/Render/CRenderContext.cpp
@@ -36,9 +36,9 @@ namespace WallpaperEngine::Render
 
         // render the background
         if (ref != this->m_wallpapers.end ())
-            ref->second->render (viewport->viewport, this->getOutput ().renderVFlip (), this->getApp().getContext().settings.render.window.scaleToFit);
+            ref->second->render (viewport->viewport, this->getOutput ().renderVFlip ());
         else
-            this->m_defaultWallpaper->render (viewport->viewport, this->getOutput ().renderVFlip (), this->getApp().getContext().settings.render.window.scaleToFit);
+            this->m_defaultWallpaper->render (viewport->viewport, this->getOutput ().renderVFlip ());
 
 #if !NDEBUG
         glPopDebugGroup ();

--- a/src/WallpaperEngine/Render/CScene.cpp
+++ b/src/WallpaperEngine/Render/CScene.cpp
@@ -6,6 +6,8 @@
 #include "WallpaperEngine/Render/Objects/CImage.h"
 #include "WallpaperEngine/Render/Objects/CSound.h"
 
+#include "WallpaperEngine/Render/CWallpaperState.h"
+
 #include "CScene.h"
 
 extern float g_Time;
@@ -14,8 +16,8 @@ extern float g_TimeLast;
 using namespace WallpaperEngine;
 using namespace WallpaperEngine::Render;
 
-CScene::CScene (Core::CScene* scene, CRenderContext& context, CAudioContext& audioContext) :
-    CWallpaper (scene, Type, context, audioContext),
+CScene::CScene (Core::CScene* scene, CRenderContext& context, CAudioContext& audioContext, const CWallpaperState::TextureUVsScaling& scalingMode) :
+    CWallpaper (scene, Type, context, audioContext, scalingMode),
     m_mousePosition (),
     m_mousePositionLast (),
     m_parallaxDisplacement ()

--- a/src/WallpaperEngine/Render/CScene.h
+++ b/src/WallpaperEngine/Render/CScene.h
@@ -15,7 +15,7 @@ namespace WallpaperEngine::Render
     class CScene : public CWallpaper
     {
     public:
-        CScene (Core::CScene* scene, CRenderContext& context, CAudioContext& audioContext);
+        CScene (Core::CScene* scene, CRenderContext& context, CAudioContext& audioContext, const CWallpaperState::TextureUVsScaling& scalingMode);
 
         CCamera* getCamera () const;
 

--- a/src/WallpaperEngine/Render/CVideo.cpp
+++ b/src/WallpaperEngine/Render/CVideo.cpp
@@ -11,8 +11,8 @@ void* get_proc_address (void* ctx, const char* name)
     return static_cast<CVideo*> (ctx)->getContext ().getDriver ().getProcAddress (name);
 }
 
-CVideo::CVideo (Core::CVideo* video, CRenderContext& context, CAudioContext& audioContext) :
-    CWallpaper (video, Type, context, audioContext),
+CVideo::CVideo (Core::CVideo* video, CRenderContext& context, CAudioContext& audioContext, const CWallpaperState::TextureUVsScaling& scalingMode) :
+    CWallpaper (video, Type, context, audioContext, scalingMode),
     m_width (16),
     m_height (16),
     m_mpvGl (nullptr)

--- a/src/WallpaperEngine/Render/CVideo.h
+++ b/src/WallpaperEngine/Render/CVideo.h
@@ -12,7 +12,7 @@ namespace WallpaperEngine::Render
     class CVideo : public CWallpaper
     {
     public:
-        CVideo (Core::CVideo* video, CRenderContext& context, CAudioContext& audioContext);
+        CVideo (Core::CVideo* video, CRenderContext& context, CAudioContext& audioContext, const CWallpaperState::TextureUVsScaling& scalingMode);
 
         Core::CVideo* getVideo ();
 

--- a/src/WallpaperEngine/Render/CWallpaper.cpp
+++ b/src/WallpaperEngine/Render/CWallpaper.cpp
@@ -219,64 +219,15 @@ void CWallpaper::render (glm::ivec4 viewport, bool vflip)
     uint32_t projectionHeight = this->getHeight ();
 
     float ustart = 0.0f;
-    float uend = 0.0f;
-    float vstart = 0.0f;
+    float uend = 1.0f;
+    float vstart = 1.0f;
     float vend = 0.0f;
 
-    if (
-        (viewport.w > viewport.z && projectionWidth >= projectionHeight) ||
-            (viewport.z > viewport.w && projectionHeight > projectionWidth)
-        )
+    if (vflip)
     {
-        if (vflip)
-        {
-            vstart = 0.0f;
-            vend = 1.0f;
-        }
-        else
-        {
-            vstart = 1.0f;
-            vend = 0.0f;
-        }
-
-        int newWidth = viewport.w / (float) projectionHeight * projectionWidth;
-        float newCenter = newWidth / 2.0f;
-        float viewportCenter = viewport.z / 2.0;
-
-        float left = newCenter - viewportCenter;
-        float right = newCenter + viewportCenter;
-
-        ustart = left / newWidth;
-        uend = right / newWidth;
+        vstart = 0.0f;
+        vend = 1.0f;
     }
-
-    if (
-        (viewport.z > viewport.w && projectionWidth >= projectionHeight) ||
-            (viewport.w > viewport.z && projectionHeight > projectionWidth)
-        )
-    {
-        ustart = 0.0f;
-        uend = 1.0f;
-
-        int newHeight = viewport.z / (float) projectionWidth * projectionHeight;
-        float newCenter = newHeight / 2.0f;
-        float viewportCenter = viewport.w / 2.0;
-
-        float down = newCenter - viewportCenter;
-        float up = newCenter + viewportCenter;
-
-        if (vflip)
-        {
-            vstart = down / newHeight;
-            vend = up / newHeight;
-        }
-        else
-        {
-            vstart = up / newHeight;
-            vend = down / newHeight;
-        }
-    }
-
     GLfloat texCoords [] = {
         ustart, vstart,
         uend, vstart,

--- a/src/WallpaperEngine/Render/CWallpaper.cpp
+++ b/src/WallpaperEngine/Render/CWallpaper.cpp
@@ -225,11 +225,12 @@ void CWallpaper::setTextureUVs(const glm::ivec4& viewport, const bool vflip, con
     if(!scale){
         uint32_t projectionWidth = this->getWidth ();
         uint32_t projectionHeight = this->getHeight ();
-
-        if (
-            (viewport.w > viewport.z && projectionWidth >= projectionHeight) ||
-                (viewport.z > viewport.w && projectionHeight > projectionWidth)
-            )
+        const float m1 = float(viewport.z) / projectionWidth;
+        const float m2 = float(viewport.w) / projectionHeight;
+        const float m = std::max(m1,m2);
+        projectionWidth*=m;
+        projectionHeight*=m;
+        if (projectionWidth!=viewport.z)
         {
             int newWidth = viewport.w / (float) projectionHeight * projectionWidth;
             float newCenter = newWidth / 2.0f;
@@ -242,10 +243,7 @@ void CWallpaper::setTextureUVs(const glm::ivec4& viewport, const bool vflip, con
             uend = right / newWidth;
         }
 
-        if (
-            (viewport.z > viewport.w && projectionWidth >= projectionHeight) ||
-                (viewport.w > viewport.z && projectionHeight > projectionWidth)
-            )
+        if (projectionHeight!=viewport.w)
         {
             int newHeight = viewport.z / (float) projectionWidth * projectionHeight;
             float newCenter = newHeight / 2.0f;

--- a/src/WallpaperEngine/Render/CWallpaper.h
+++ b/src/WallpaperEngine/Render/CWallpaper.h
@@ -14,6 +14,8 @@
 #include "WallpaperEngine/Render/CFBO.h"
 #include "WallpaperEngine/Render/Helpers/CContextAware.h"
 
+#include "CWallpaperState.h"
+
 using namespace WallpaperEngine::Assets;
 using namespace WallpaperEngine::Audio;
 
@@ -35,14 +37,9 @@ namespace WallpaperEngine::Render
         ~CWallpaper ();
 
         /**
-         * Get texture UV coordinates for render
-         */
-        void setTextureUVs(const glm::ivec4& viewport, const bool vflip, const bool scale, 
-            float& ustart, float& uend, float& vstart, float& vend);
-        /**
          * Performs a render pass of the wallpaper
          */
-        void render (glm::ivec4 viewport, bool vflip, bool scale);
+        void render (glm::ivec4 viewport, bool vflip);
 
         /**
          * @return The container to resolve files for this wallpaper
@@ -88,9 +85,9 @@ namespace WallpaperEngine::Render
         [[nodiscard]] CFBO* getFBO () const;
 
         /**
-         * Updates the texcoord used for drawing to the used framebuffer
+         * Updates the UVs coordinates if window/screen/vflip/projection has changed 
          */
-        void updateTexCoord (GLfloat* texCoords, GLsizeiptr size) const;
+        void updateUVs (const glm::ivec4& viewport, const bool vflip);
 
         /**
          * Updates the destination framebuffer for this wallpaper
@@ -116,10 +113,10 @@ namespace WallpaperEngine::Render
          *
          * @return
          */
-        static CWallpaper* fromWallpaper (Core::CWallpaper* wallpaper, CRenderContext& context, CAudioContext& audioContext);
+        static CWallpaper* fromWallpaper (Core::CWallpaper* wallpaper, CRenderContext& context, CAudioContext& audioContext, const CWallpaperState::TextureUVsScaling& scalingMode);
 
     protected:
-        CWallpaper (Core::CWallpaper* wallpaperData, std::string type, CRenderContext& context, CAudioContext& audioContext);
+        CWallpaper (Core::CWallpaper* wallpaperData, std::string type, CRenderContext& context, CAudioContext& audioContext,  const CWallpaperState::TextureUVsScaling& scalingMode);
 
         /**
          * Renders a frame of the wallpaper
@@ -158,5 +155,7 @@ namespace WallpaperEngine::Render
         std::map<std::string, CFBO*> m_fbos;
         /** Audio context that is using this wallpaper */
         CAudioContext& m_audioContext;
+        /** Current Wallpaper state */
+        CWallpaperState m_state;
     };
 }

--- a/src/WallpaperEngine/Render/CWallpaper.h
+++ b/src/WallpaperEngine/Render/CWallpaper.h
@@ -35,9 +35,14 @@ namespace WallpaperEngine::Render
         ~CWallpaper ();
 
         /**
+         * Get texture UV coordinates for render
+         */
+        void setTextureUVs(const glm::ivec4& viewport, const bool vflip, const bool scale, 
+            float& ustart, float& uend, float& vstart, float& vend);
+        /**
          * Performs a render pass of the wallpaper
          */
-        void render (glm::ivec4 viewport, bool vflip);
+        void render (glm::ivec4 viewport, bool vflip, bool scale);
 
         /**
          * @return The container to resolve files for this wallpaper

--- a/src/WallpaperEngine/Render/CWallpaperState.cpp
+++ b/src/WallpaperEngine/Render/CWallpaperState.cpp
@@ -1,0 +1,170 @@
+#include "CWallpaperState.h"
+#include <algorithm>
+#include "WallpaperEngine/Logging/CLog.h"
+
+using namespace WallpaperEngine::Render;
+
+// Reset UVs to 0/1 values
+void CWallpaperState::resetUVs(){
+    this->UVs.ustart=0;
+    this->UVs.uend=1;
+    if (vflip){
+        this->UVs.vstart = 0.0f;
+        this->UVs.vend = 1.0f;
+    }
+    else{
+        this->UVs.vstart=1.0f;
+        this->UVs.vend=0.0f;
+    }
+}
+
+// Update Us coordinates for current viewport and projection
+void CWallpaperState::updateUs(const int& projectionWidth, const int& projectionHeight){
+    const float viewportWidth  = this->getViewportWidth();
+    const float viewportHeight = this->getViewportHeight();
+    int newWidth = viewportHeight  / projectionHeight * projectionWidth;
+    float newCenter = newWidth / 2.0f;
+    float viewportCenter = viewportWidth / 2.0;
+
+    float left = newCenter - viewportCenter;
+    float right = newCenter + viewportCenter;
+
+    this->UVs.ustart = left / newWidth;
+    this->UVs.uend   = right / newWidth;
+}
+
+// Update Vs coordinates for current viewport and projection 
+void CWallpaperState::updateVs(const int& projectionWidth, const int& projectionHeight){
+    const float viewportWidth  = this->getViewportWidth();
+    const float viewportHeight =  this->getViewportHeight();
+    int newHeight = viewportWidth / projectionWidth * projectionHeight;
+    float newCenter = newHeight / 2.0f;
+    float viewportCenter = viewportHeight / 2.0;
+
+    float down = newCenter - viewportCenter;
+    float up = newCenter + viewportCenter;
+
+    if (vflip)
+    {
+        this->UVs.vstart = down / newHeight;
+        this->UVs.vend = up / newHeight;
+    }
+    else
+    {
+        this->UVs.vstart = up / newHeight;
+        this->UVs.vend = down / newHeight;
+    }
+}
+
+
+template<> void CWallpaperState::updateTextureUVs<CWallpaperState::TextureUVsScaling::StretchUVs>(){
+    this->resetUVs();
+}
+
+template<> void CWallpaperState::updateTextureUVs<CWallpaperState::TextureUVsScaling::ZoomFillUVs>(){
+    this->resetUVs();
+
+    const int viewportWidth  = this->getViewportWidth();
+    const int viewportHeight =  this->getViewportHeight();
+    uint32_t projectionWidth = this->getProjectionWidth();
+    uint32_t projectionHeight = this->getProjectionHeight();
+
+    const float m1 = static_cast<float>(viewportWidth) / projectionWidth;
+    const float m2 = static_cast<float>(viewportHeight) / projectionHeight;
+    const float m = std::max(m1,m2);
+    projectionWidth*=m;
+    projectionHeight*=m;
+
+    if (projectionWidth!=viewportWidth)
+    {
+        this->updateUs(projectionWidth,projectionHeight);
+    }
+    else if (projectionHeight!=viewportHeight)
+    {
+        this->updateVs(projectionWidth,projectionHeight);
+    }
+}
+
+template<> void CWallpaperState::updateTextureUVs<CWallpaperState::TextureUVsScaling::ZoomFitUVs>(){
+    this->resetUVs();
+    
+    const int viewportWidth  = this->getViewportWidth();
+    const int viewportHeight =  this->getViewportHeight();
+    uint32_t projectionWidth = this->getProjectionWidth();
+    uint32_t projectionHeight = this->getProjectionHeight();
+
+    const float m1 = static_cast<float>(viewportWidth) / projectionWidth;
+    const float m2 = static_cast<float>(viewportHeight) / projectionHeight;
+    const float m = std::min(m1,m2);
+    projectionWidth*=m;
+    projectionHeight*=m;
+
+    if (projectionWidth!=viewportWidth)
+    {
+        this->updateUs(projectionWidth,projectionHeight);
+    }
+    else if (projectionHeight!=viewportHeight)
+    {
+        this->updateVs(projectionWidth,projectionHeight);
+    }
+}
+
+template<> void CWallpaperState::updateTextureUVs<CWallpaperState::TextureUVsScaling::DefaultUVs>(){
+    this->resetUVs();
+
+    const int viewportWidth  = this->getViewportWidth();
+    const int viewportHeight =  this->getViewportHeight();
+    uint32_t projectionWidth = this->getProjectionWidth();
+    uint32_t projectionHeight = this->getProjectionHeight();
+
+    if (
+        (viewportHeight > viewportWidth && projectionWidth >= projectionHeight) ||
+            (viewportWidth > viewportHeight && projectionHeight > projectionWidth)
+        )
+    {
+        updateUs(projectionWidth,projectionHeight);
+    }
+
+    if (
+        (viewportWidth > viewportHeight && projectionWidth >= projectionHeight) ||
+            (viewportHeight > viewportWidth && projectionHeight > projectionWidth)
+        )
+    {
+        updateVs(projectionWidth,projectionHeight);
+    }
+}
+
+template<CWallpaperState::TextureUVsScaling T> void CWallpaperState::updateTextureUVs(){
+    sLog.exception("Using generic template for scaling is not allowed. Write specialization template for your scaling mode.\
+     This message is for developers, if you are just user it's a bug.");
+}
+
+
+void CWallpaperState::updateState(const glm::ivec4& viewport, const bool& vflip, const int& projectionWidth, const int& projectionHeight){
+    this->viewport.width = viewport.z;
+    this->viewport.height = viewport.w;
+    this->vflip = vflip;
+    this->projection.width = projectionWidth;
+    this->projection.height = projectionHeight;
+
+    //Set texture UVs according to choosen scaling mode for this wallpaper
+    switch (this->getTextureUVsScaling())
+    {
+        case CWallpaperState::TextureUVsScaling::StretchUVs :
+            this->updateTextureUVs<CWallpaperState::TextureUVsScaling::StretchUVs>();
+            break;
+        case CWallpaperState::TextureUVsScaling::ZoomFillUVs :
+            this->updateTextureUVs<CWallpaperState::TextureUVsScaling::ZoomFillUVs>();
+            break;
+        case CWallpaperState::TextureUVsScaling::ZoomFitUVs :
+            this->updateTextureUVs<CWallpaperState::TextureUVsScaling::ZoomFitUVs>();
+            break;
+        case CWallpaperState::TextureUVsScaling::DefaultUVs :
+            this->updateTextureUVs<CWallpaperState::TextureUVsScaling::DefaultUVs>();
+            break;
+        default:
+            sLog.exception("Switch case for specified scaling mode doesn't exist. Add your realisation in switch statement.\
+                This message is for developers, if you are just user it's a bug.");
+            break;
+    }
+}

--- a/src/WallpaperEngine/Render/CWallpaperState.h
+++ b/src/WallpaperEngine/Render/CWallpaperState.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <glm/vec4.hpp>
+
+namespace WallpaperEngine::Render
+{
+    /**
+     * Represents current wallpaper state
+     */
+    class CWallpaperState
+    {
+    public:
+        // Scaling modes. Defines how UVs coordinates are calculated.
+        enum class TextureUVsScaling : uint8_t
+        {
+            DefaultUVs,
+            ZoomFitUVs,
+            ZoomFillUVs,
+            StretchUVs,
+        };
+
+        CWallpaperState(const TextureUVsScaling& textureUVsMode) : m_textureUVsMode(textureUVsMode)
+        {};
+
+        // Compares saved state values with passed arguments
+        bool hasChanged(const glm::ivec4& viewport, const bool& vflip, const int& projectionWidth, const int& projectionHeight) const{
+            return this->viewport.width != viewport.z || this->viewport.height != viewport.w || 
+                this->projection.width != projectionWidth || this->projection.height != projectionHeight || this->vflip != vflip;
+        }
+
+        // Reset UVs to 0/1 values
+        void resetUVs();
+        
+        // Update Us coordinates for current viewport and projection
+        void updateUs(const int& projectionWidth, const int& projectionHeight);
+
+        // Update Vs coordinates for current viewport and projection 
+        void updateVs(const int& projectionWidth, const int& projectionHeight);
+
+        // Get texture UV coordinates
+        auto getTextureUVs() const {return UVs;};
+
+        // Set texture UV coordinates according to texture scaling mode
+        template<CWallpaperState::TextureUVsScaling> void updateTextureUVs();
+        
+        // Updates state with provided values
+        void updateState(const glm::ivec4& viewport, const bool& vflip, const int& projectionWidth, const int& projectionHeight);
+
+        // @return The texture scaling mode
+        TextureUVsScaling getTextureUVsScaling ()  const { return m_textureUVsMode; };
+
+        // Set texture scaling mode
+        void setTextureUVsStrategy(const TextureUVsScaling strategy) { m_textureUVsMode=strategy; } ;
+
+        // @return The width of viewport
+        int getViewportWidth () const { return viewport.width;};
+
+        // @return The height of viewport
+        int getViewportHeight () const { return viewport.height;};
+
+        // @return The width of viewport
+        uint32_t getProjectionWidth () const { return projection.width;};
+
+        // @return The height of viewport
+        uint32_t getProjectionHeight () const { return projection.height;};
+
+    private:
+        // Cached UVs value for texture coordinates. No need to recalculate if viewport and projection haven't changed.
+        struct
+        {
+            float ustart;
+            float uend;
+            float vstart;
+            float vend;
+        } UVs;
+
+        // Viewport for which UVs were calculated
+        struct
+        {
+            int width;
+            int height;
+        } viewport{};
+
+        // Wallpaper dimensions
+        struct
+        {
+            uint32_t width;
+            uint32_t height;
+        } projection{};
+
+        // Are Vs coordinates fliped
+        bool vflip = false;
+
+        // Texture scaling mode
+        TextureUVsScaling m_textureUVsMode = TextureUVsScaling::DefaultUVs;
+    };
+}

--- a/src/WallpaperEngine/Render/Drivers/Output/CGLFWWindowOutput.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/CGLFWWindowOutput.cpp
@@ -1,3 +1,4 @@
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 #include "CGLFWWindowOutput.h"
 #include "WallpaperEngine/Logging/CLog.h"


### PR DESCRIPTION
# Fix for issue #173. 
### Short description
Video gets clamped for **[2659503088](https://steamcommunity.com/sharedfiles/filedetails/?id=2659503088)** wallpaper. Problem is caused by texture coordinates being out of boundaries, resulting in clamp.
### Full description
Texture UV coordinates starts from **0** and ends at **1**. We will change _uend_ and see how it will affect video **[2667198601](https://steamcommunity.com/sharedfiles/filedetails/?id=2667198601)**.
If we have:
```
float ustart = 0.0f;
float uend = 1.0f;
float vstart = 1.0f;
float vend = 0.0f;
```
we will get full size video:
![image](https://github.com/Almamu/linux-wallpaperengine/assets/43461852/63db7eef-11aa-43ca-912d-8997f498e626)

And if we have:
```
float ustart = 0.0f;
float uend = 0.5f;
float vstart = 1.0f;
float vend = 0.0f;
```
we will get only left halve of video:
![image](https://github.com/Almamu/linux-wallpaperengine/assets/43461852/be2ae186-ee1e-4f41-962b-dee059a0519a)

And if we  try to render texture out of this boundries:
```
float ustart = 0.0f;
float uend = 1.5f;
float vstart = 1.0f;
float vend = 0.0f;
```
texture will be clamped to the edge (because _GL_CLAMP_TO_EDGE_ parametr in _CFBO.cpp_ is set):
![image](https://github.com/Almamu/linux-wallpaperengine/assets/43461852/d4129eaa-c145-459f-963b-e5ccdc1fa1ff)

### What caused problem
Previously, _ustart/uend_ or _vstart/vend_ could be less than **0** or bigger than **1** (for example _ustart_ could be **-0.16** and _uend_ could be **1.15**), resulting in texture clamping on _left/right_ or _top/bottom_ of window or screen(though I only had _top/bottom_ clamp). By making them equal to **0** or **1** accordingly, we make sure that **OpenGL** renders whole texture with _glDrawArrays_ and don't get out of boundaries so we have no clamping.

**Before:**
![image](https://github.com/Almamu/linux-wallpaperengine/assets/43461852/6e4e26db-1f3c-47a3-be8f-4a1d3fcb1f97)

**After:**
![image](https://github.com/Almamu/linux-wallpaperengine/assets/43461852/85314cdc-74f4-47f4-b396-b03fe7b1ff1c)

### Additional concerns
It probably shouldn't affect people from issue #81, but may be it's a good idea to ask if everything works fine for them.
