### PR TITLE
Clean Exit on Display Help

### DIFF
--- a/src/WallpaperEngine/Application/CApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/CApplicationContext.cpp
@@ -3,6 +3,7 @@
 #include "Steam/FileSystem/FileSystem.h"
 #include "WallpaperEngine/Logging/CLog.h"
 
+#include <cstdlib>
 #include <cstring>
 #include <getopt.h>
 
@@ -167,6 +168,7 @@ CApplicationContext::CApplicationContext (int argc, char* argv[])
 
             case 'h':
                 printHelp (argv[0]);
+		std::exit(0);
                 break;
 
             case 'f':
@@ -209,6 +211,7 @@ CApplicationContext::CApplicationContext (int argc, char* argv[])
         else
         {
             printHelp (argv[0]);
+	    std::exit(0);
         }
     }
 


### PR DESCRIPTION
### Fix for #181 
Current behavior when `linux-wallpaperengine` with the `-h` or `--help` flags is to display a blank window, segfault, and display the help message (sometimes twice). This PR fixes that by cleanly exiting after displaying the help message when `-h` or `--help` are passed. This should help avoid erroneous issue tickets.