### PR TITLE
Workaround errors when loading wallpapers made recently

### DIFF
--- a/src/WallpaperEngine/Render/Objects/Effects/CPass.cpp
+++ b/src/WallpaperEngine/Render/Objects/Effects/CPass.cpp
@@ -451,7 +451,7 @@ void CPass::setupUniforms () {
                     // resolve the texture first
                     const ITexture* textureRef;
 
-                    if (textureName.find ("_rt_") == 0) {
+                    if (textureName.find ("_rt_") == 0 || textureName.find ("_alias_") == 0) {
                         textureRef = this->getMaterial ()->getEffect ()->findFBO (textureName);
 
                         if (textureRef == nullptr)

--- a/src/WallpaperEngine/Render/Shaders/Compiler.cpp
+++ b/src/WallpaperEngine/Render/Shaders/Compiler.cpp
@@ -265,6 +265,15 @@ void Compiler::precompile () {
                     this->m_includesContent += this->lookupShaderFile (filename);
                     this->m_includesContent += "\r\n// end of included from file " + filename + "\r\n";
                 }
+            } else if (this->peekString ("#require ", it)) {
+                // TODO: PROPERLY IMPLEMENT #require
+                this->m_compiledContent += "// #require ";
+                // ignore whitespaces
+                this->ignoreSpaces (it);
+                BREAK_IF_ERROR
+                std::string name = this->extractName (it);
+                BREAK_IF_ERROR
+                this->m_compiledContent += name;
             } else {
                 this->m_compiledContent += '#';
                 ++it;

--- a/src/WallpaperEngine/Render/Shaders/Compiler.cpp
+++ b/src/WallpaperEngine/Render/Shaders/Compiler.cpp
@@ -694,7 +694,7 @@ void Compiler::parseParameterConfiguration (const std::string& type, const std::
             value = *constant->second->as<CShaderConstantInteger> ()->getValue ();
 
         parameter = new Variables::CShaderVariableInteger (value);
-    } else if (type == "sampler2D") {
+    } else if (type == "sampler2D" || type == "sampler2DComparison") {
         // samplers can have special requirements, check what sampler we're working with and create definitions
         // if needed
         const auto textureName = data.find ("default");
@@ -755,7 +755,8 @@ const std::map<int, std::string>& Compiler::getTextures () const {
     return this->m_textures;
 }
 
-std::vector<std::string> Compiler::sTypes = {
-    "vec4",  "uvec4", "ivec4", "dvec4", "bvec4", "vec3",      "uvec3",  "ivec3", "dvec3", "bvec3", "vec2",
-    "uvec2", "ivec2", "dvec2", "bvec2", "float", "sampler2D", "mat4x3", "mat4",  "mat3",  "uint4", "void"};
+std::vector<std::string> Compiler::sTypes = {"vec4",   "uvec4", "ivec4", "dvec4", "bvec4",     "vec3",
+                                             "uvec3",  "ivec3", "dvec3", "bvec3", "vec2",      "uvec2",
+                                             "ivec2",  "dvec2", "bvec2", "float", "sampler2D", "sampler2DComparison",
+                                             "mat4x3", "mat4",  "mat3",  "uint",  "uint4",     "void"};
 } // namespace WallpaperEngine::Render::Shaders


### PR DESCRIPTION
Recent assets introduced new types such as sampler2DComparison:
```
❯ rg sampler2DComparison
assets/shaders/volumetricsfront.frag
11:uniform sampler2DComparison g_Texture0; // {"hidden":true,"default":"_rt_shadowAtlas"}

assets/shaders/chroma4.frag
23:uniform sampler2DComparison g_Texture6; // {"hidden":true,"default":"_rt_shadowAtlas"}

assets/shaders/generic4.frag
24:uniform sampler2DComparison g_Texture6; // {"hidden":true,"default":"_rt_shadowAtlas"}

assets/shaders/foliage4.frag
25:uniform sampler2DComparison g_Texture6; // {"hidden":true,"default":"_rt_shadowAtlas"}

assets/shaders/genericimage4.frag
9:uniform sampler2DComparison g_Texture6; // {"hidden":true,"default":"_rt_shadowAtlas"}

assets/shaders/fur4.frag
23:uniform sampler2DComparison g_Texture6; // {"hidden":true,"default":"_rt_shadowAtlas"}

assets/effects/fluidsimulation/shaders/effects/fluidsimulation_combine.frag
12:uniform sampler2DComparison g_Texture6; // {"hidden":true,"default":"_rt_shadowAtlas"}
```

This PR adds some workarounds to make new wallpapers load (but not guaranteed to render correctly)

For example, 3312993556 loads after this PR, but is not correctly rendered, so further work is required.