### PR TITLE
fix: use proper CEF string conversion to avoid delete on unallocated object

### DIFF
--- a/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp
+++ b/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp
@@ -75,12 +75,13 @@ WebBrowserContext::WebBrowserContext (WallpaperEngine::Application::WallpaperApp
 
     // Configurate Chromium
     CefSettings settings;
+    std::string cache_path = (std::filesystem::temp_directory_path() / uuid::generate_uuid_v4()).string();
     // CefString(&settings.locales_dir_path) = "OffScreenCEF/godot/locales";
     // CefString(&settings.resources_dir_path) = "OffScreenCEF/godot/";
     // CefString(&settings.framework_dir_path) = "OffScreenCEF/godot/";
     // CefString(&settings.cache_path) = "OffScreenCEF/godot/";
     //  CefString(&settings.browser_subprocess_path) = "path/to/client"
-    CefString(&settings.root_cache_path) = std::filesystem::temp_directory_path() / uuid::generate_uuid_v4();
+    cef_string_utf8_to_utf16(cache_path.c_str(), cache_path.length(), &settings.root_cache_path);
     settings.windowless_rendering_enabled = true;
 #if defined(CEF_NO_SANDBOX)
     settings.no_sandbox = true;


### PR DESCRIPTION
Fix build failed with cef_binary_139.0.40+g465474a+chromium-139.0.7258.139

```sh
In member function ‘void CefStringBase<traits>::ClearAndFree() [with traits = CefStringTraitsUTF16]’,
    inlined from ‘CefStringBase<traits>::~CefStringBase() [with traits = CefStringTraitsUTF16]’ at /dev/BUILD/linux-wallpaperengine/src/build/cef/cef_binary_139.0.40+g465474a+chromium-139.0.7258.139_linux64/include/internal/cef_string_wrappers.h:446:34,
    inlined from ‘WallpaperEngine::WebBrowser::WebBrowserContext::WebBrowserContext(WallpaperEngine::Application::WallpaperApplication&)’ at /dev/BUILD/linux-wallpaperengine/src/linux-wallpaperengine-git/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp:83:5:
/dev/BUILD/linux-wallpaperengine/src/build/cef/cef_binary_139.0.40+g465474a+chromium-139.0.7258.139_linux64/include/internal/cef_string_wrappers.h:540:7: error: ‘void operator delete(void*, std::size_t)’ called on unallocated object ‘settings’ [-Werror=free-nonheap-object]
  540 |       delete string_;
      |       ^~~~~~~~~~~~~~
/dev/BUILD/linux-wallpaperengine/src/linux-wallpaperengine-git/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp: In constructor ‘WallpaperEngine::WebBrowser::WebBrowserContext::WebBrowserContext(WallpaperEngine::Application::WallpaperApplication&)’:
/dev/BUILD/linux-wallpaperengine/src/linux-wallpaperengine-git/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp:77:17: note: declared here
   77 |     CefSettings settings;
      |                 ^~~~~~~~
```

Replace direct filesystem::path assignment with cef_string_utf8_to_utf16() to prevent destructor from deleting stack-allocated memory.