### PR TITLE
cmake: add CEF_DISTRIBUTION_TYPE option for configurable CEF binary builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ set(KISSFFT_TOOLS OFF)
 # Download CEF of specified version for current platform
 # Specify the CEF distribution version.
 set(CEF_VERSION "135.0.17+gcbc1c5b+chromium-135.0.7049.52")
+set(CEF_DISTRIBUTION_TYPE "minimal" CACHE STRING "CEF distribution variant")
+set_property(CACHE CEF_DISTRIBUTION_TYPE PROPERTY STRINGS "minimal" "standard")
 # Determine the platform.
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     if("${PROJECT_ARCH}" STREQUAL "arm64")
@@ -91,6 +93,10 @@ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
         set(CEF_PLATFORM "windows32")
         set(CEF_ARCH_DETECTION "Default for Windows")
     endif()
+endif()
+
+if(CEF_DISTRIBUTION_TYPE AND NOT CEF_DISTRIBUTION_TYPE STREQUAL "standard")
+    set(CEF_PLATFORM "${CEF_PLATFORM}_${CEF_DISTRIBUTION_TYPE}")
 endif()
 message(STATUS "Using CEF for ${CMAKE_SYSTEM_NAME} - ${CEF_PLATFORM} (${CEF_ARCH_DETECTION})")
 include(DownloadCEF)


### PR DESCRIPTION
We do not use debug build binary files or sample application source code, so we just need to build on the minimal distribution. It is only around ~360 MB instead of ~770 MB for the standard distribution, which may help speed up downloading and extracting a bit. So, just build on the minimal distribution as default.