### PR TITLE
fix: apply scaling to height calculation in Wayland output

### DIFF
--- a/src/WallpaperEngine/Render/Drivers/Output/WaylandOutput.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/WaylandOutput.cpp
@@ -20,8 +20,8 @@ void WaylandOutput::updateViewports () {
         m_viewports [o->name] = o;
 
         fullw = fullw + glm::ivec2 {o->size.x * o->scale, 0};
-        if (o->size.y > fullw.y)
-            fullw.y = o->size.y;
+        if (o->size.y * o->scale > fullw.y)
+            fullw.y = o->size.y * o->scale;
     }
 
     m_fullWidth = fullw.x;


### PR DESCRIPTION
When calculating full output dimensions for Wayland displays with scaling, the height was not being multiplied by the scale factor while the width was.

This caused a buffer size mismatch in takeScreenshot() where the bitmap was allocated with unscaled height but filled with scaled pixel data, resulting in a segmentation fault when using --screenshot on monitors with scale != 1.0.

Tested on hyprland with monitor scale 1.33. Before this change:
```
linux-wallpaperengine --bg 1998959940 --silent --screenshot ./test1.jpg --scaling fill --screen-root eDP-1
Running with: ./linux-wallpaperengine --bg 1998959940 --silent --screenshot ./test1.jpg --scaling fill --screen-root eDP-1
/usr/bin/linux-wallpaperengine: line 3: 56821 Segmentation fault         (core dumped) ./linux-wallpaperengine "$@"
```
After this change, segmentation fault no longer happens.