### PR TITLE
Add Alt Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ sudo apt-get update
 sudo apt-get install build-essential cmake libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev libglew-dev freeglut3-dev libsdl2-dev liblz4-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libxxf86vm-dev libglm-dev libglfw3-dev libmpv-dev mpv libmpv2 libpulse-dev libpulse0 libfftw3-dev
 ```
 
+### Alt linux
+```bash
+sudo epm update
+sudo epm install gcc-c++ make cmake libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel libGL-devel libGLEW-devel freeglut-devel libSDL2-devel liblz4-devel libavcodec-devel libavformat-devel libavutil-devel libswscale-devel libXxf86vm-devel libglm-devel libglfw3-devel libmpv-devel mpv libpulseaudio-devel libpulseaudio libfftw3-devel libpng-devel libffi-devel libswresample-devel libgmpxx-devel
+```
+
 Install the required dependencies on RHEL/Fedora-based systems:
 
 ### Fedora 42
 ```bash
 sudo dnf update
 sudo dnf install gcc g++ cmake libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel glew-devel freeglut-devel SDL2-devel lz4-devel ffmpeg ffmpeg-free-devel libXxf86vm-devel glm-devel glfw-devel mpv mpv-devel pulseaudio-libs-devel fftw-devel
-```
-
-### Alt linux
-```bash
-sudo epm update
-sudo epm install gcc-c++ make cmake libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel libGL-devel libGLEW-devel freeglut-devel libSDL2-devel liblz4-devel libavcodec-devel libavformat-devel libavutil-devel libswscale-devel libXxf86vm-devel libglm-devel libglfw3-devel libmpv-devel mpv libpulseaudio-devel libpulseaudio libfftw3-devel libpng-devel libffi-devel libswresample-devel libgmpxx-devel
 ```
 
 ---


### PR DESCRIPTION
### What
Added dependency installation commands for Alt Linux (Sisyphus) to the README.

### Why
Alt Linux uses RPM packaging with different naming conventions (`-devel` suffix, capitalized X11 libs). Current README only covers Ubuntu/Debian/fedora and Arch.

#### Translation table (ubuntu <-> alt)
| Debian/Ubuntu Package | Alt Linux Package | Notes |
|---|---|---|
| build-essential | gcc-c++ make | No metapackage; install separately |
| cmake | cmake | Same name |
| libxrandr-dev | libXrandr-devel | Capital X |
| libxinerama-dev | libXinerama-devel | Capital X |
| libxcursor-dev | libXcursor-devel | Capital X |
| libxi-dev | libXi-devel | Capital X and I |
| libgl-dev | libGL-devel | Capital GL |
| libglew-dev | libGLEW-devel | Capital GLEW |
| freeglut3-dev | freeglut-devel | No version number |
| libsdl2-dev | libSDL2-devel | Capital SDL |
| liblz4-dev | liblz4-devel | `-dev` → `-devel` |
| libavcodec-dev | libavcodec-devel | Part of ffmpeg |
| libavformat-dev | libavformat-devel | Part of ffmpeg |
| libavutil-dev | libavutil-devel | Part of ffmpeg |
| libswscale-dev | libswscale-devel | Part of ffmpeg |
| (missing) | libswresample-devel | **Required**, discovered during build |
| libxxf86vm-dev | libXxf86vm-devel | Capital X |
| libglm-dev | libglm-devel | `-dev` → `-devel` |
| libglfw3-dev | libglfw3-devel | Keep version number |
| libmpv-dev | libmpv-devel | `-dev` → `-devel` |
| mpv | mpv | Same name |
| libmpv1/libmpv2 | (included in libmpv-devel) | No separate runtime lib |
| libpulse-dev | libpulseaudio-devel | Different base name |
| libpulse0 | libpulseaudio | Different base name |
| libfftw3-dev | libfftw3-devel | `-dev` → `-devel` |
| (missing) | libpng-devel | **Required**, discovered during build |
| (missing) | libffi-devel | **Required** for wayland-client |
| (missing) | libgmpxx-devel | **Required** for gmpxx.h |

### Changes
- Added new section "Alt Linux" under System Requirements
- Translated all Ubuntu package names to Alt Linux equivalents:
  - `build-essential` → `gcc-c++ make`
  - `-dev` suffix → `-devel` suffix
  - Proper X11 library capitalization (`libXrandr-devel`)
  - Added missing dependencies (`libgmpxx-devel`, `libffi-devel`, `libpng-devel`, `libswresample-devel`)


### Testing
Verified all packages exist in Sisyphus repo and successfully built linux-wallpaperengine on:
```bash
$ epm print info
distro_info v20250206 (EPM version 3.64.38-alt1) : Copyright © 2007-2025 Etersoft

                       Pretty name (--pretty): ALT Regular (Sisyphus)
           (--distro-name / --distro-version): ALT Linux / Sisyphus (orig. Sisyphus 20250612)
         Base distro name (-d) / version (-v): ALTLinux/Sisyphus
     Vendor distro name (-s) / Repo name (-r): alt / Sisyphus
                 Package manager/type (-g/-p): apt-rpm / rpm
            Base OS name (-o) / CPU arch (-a): linux x86_64
                 CPU norm register size  (-b): 64 bit
                          Virtualization (-i): (host system)
                        CPU Cores/MHz (-c/-z): 6 / 5504 MHz
                      System memory size (-m): 61869 MiB
                 Running service manager (-y): systemd
            Bug report URL (--bug-report-url): https://bugs.altlinux.org/
```