### PR TITLE
fix: UVs for padded/non-POT textures in CImage

### DIFF
--- a/src/WallpaperEngine/Render/Objects/CImage.cpp
+++ b/src/WallpaperEngine/Render/Objects/CImage.cpp
@@ -140,16 +140,11 @@ CImage::CImage (Wallpapers::CScene& scene, const Image& image) :
     else if (this->getTexture () != nullptr &&
              (this->getTexture ()->getTextureWidth (0) != this->getTexture ()->getRealWidth () ||
               this->getTexture ()->getTextureHeight (0) != this->getTexture ()->getRealHeight ())) {
-        uint32_t x = 1;
-        uint32_t y = 1;
-
-        while (x < size.x)
-            x <<= 1;
-        while (y < size.y)
-            y <<= 1;
-
-        width = scaledSize.x / x;
-        height = scaledSize.y / y;
+        // Account for padding in non-power-of-two textures: clamp UVs to the real content
+        width = static_cast<float> (this->getTexture ()->getRealWidth ()) /
+                static_cast<float> (this->getTexture ()->getTextureWidth (0));
+        height = static_cast<float> (this->getTexture ()->getRealHeight ()) /
+                 static_cast<float> (this->getTexture ()->getTextureHeight (0));
     }
 
     // TODO: RECALCULATE THESE POSITIONS FOR PASSTHROUGH SO THEY TAKE THE RIGHT PART OF THE TEXTURE


### PR DESCRIPTION
No longer use the power-of-two heuristic for atlas UVs. Instead, clamp UVs to the real texture dimensions (realWidth/textureWidth, realHeight/textureHeight) so padded areas aren’t sampled. Previously the padded area was being sampled which would cause things to be rendered offset

I tested against 15 or so wallpapers and didn't see any regressions. 

An example of a wallpaper which had issues is https://steamcommunity.com/sharedfiles/filedetails/?id=3387894615

Before:
<img width="1288" height="747" alt="image" src="https://github.com/user-attachments/assets/a6181844-ee77-4041-8c94-68db3da23fef" />
After:
<img width="1287" height="750" alt="image" src="https://github.com/user-attachments/assets/84fb10a0-648a-4391-a67e-9c95096769be" />
