### PR TITLE
use GLEW::GLEW imported target to fix builds on openSUSE Tumbleweed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ if(WAYLAND_SUPPORT_FOUND)
         COMMAND ${WaylandScanner} private-code ${WAYLAND_PROTOCOLS_DIR}/stable/xdg-shell/xdg-shell.xml ${WAYLAND_OUTPUT_DIR}/xdg-shell-protocol.c)
 
     add_compile_definitions(ENABLE_WAYLAND)
+    include_directories(${WAYLAND_SUPPORT_INCLUDE_DIRS})
     include_directories(${WAYLAND_OUTPUT_DIR})
     set(WAYLAND_LIBRARIES
         pthread


### PR DESCRIPTION
on some distributions like openSUSE Tumbleweed, GLEW ships with its own 
GLEWConfig.cmake that only provides the GLEW::GLEW imported target and 
does not set the legacy GLEW_LIBRARIES variable. this breaks the ability to build on those distributions  
(see issue #422).

the GLEW::GLEW imported target has been available since CMake 3.1 (2014) 
in both FindGLEW and modern GLEWConfig.cmake files, making it the more 
portable solution.

my apologies if i did something wrong with this pull request, this is my first time contributing to a third party project like this.

