### PR TITLE
fix: correct wrong video wallpaper opening if file of equal name is in the home directory

### DIFF
--- a/src/WallpaperEngine/Application/WallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/WallpaperApplication.cpp
@@ -93,6 +93,11 @@ AssetLocatorUniquePtr WallpaperApplication::setupAssetLocator (const std::string
         sLog.exception ("Cannot find a valid assets folder, resolved to ", this->m_context.settings.general.assets);
     }
 
+    // mount the current directory as root
+    try {
+        container->mount (std::filesystem::current_path (), "/");
+    } catch (std::runtime_error&) { }
+
     auto& vfs = container->getVFS ();
 
     //

--- a/src/WallpaperEngine/FileSystem/Container.cpp
+++ b/src/WallpaperEngine/FileSystem/Container.cpp
@@ -31,8 +31,6 @@ Container::Container () {
 
     this->m_vfs = std::make_shared<VirtualAdapter> ();
     this->m_mountpoints.emplace_back ("/", this->m_vfs);
-    // mount the current directory as root
-    this->mount (std::filesystem::current_path (), "/");
 }
 
 ReadStreamSharedPtr Container::read (const std::filesystem::path& path) const {


### PR DESCRIPTION
When searching for a wallpaper: The `/home/<USER>` directory will be mounted alongside the Wallpaper Engine assets directory. And because it is mounted before all others, if there happens to be a file with the same name as the wallpaper in the user's home folder, that file will then be chosen as the wallpaper instead of the real one.

This addresses issue #446 

To fix this issue I moved the home mounting logic out of the constructor and placed it below the assets folder.