### PR TITLE
Use `exec` when lauching program

### DIFF
--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -47,7 +47,7 @@ package() {
     cat > "${pkgdir}/usr/bin/${_pkgname}" << EOF
 #!/bin/bash
 export LD_LIBRARY_PATH="/opt/${_pkgname}/lib:\$LD_LIBRARY_PATH"
-cd /opt/${_pkgname}; ./${_pkgname} "\$@"
+cd /opt/${_pkgname}; exec ./${_pkgname} "\$@"
 EOF
     chmod +x ${pkgdir}/usr/bin/${_pkgname}
     chmod +x ${pkgdir}/opt/${_pkgname}/linux-wallpaperengine


### PR DESCRIPTION
Using exec means that wrapper scripts can properly terminate processes. I was trying to use the `MikiDevLog/wallpaperengine-gui` gui and was having problem when stopping a wallpaper or quitting the program where the wallpapers would never stop. Running with `exec` now kill processes properly.