### PR TITLE
Add gmp-devel to the list of dependencies for the Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install the required dependencies on RHEL/Fedora-based systems:
 ### Fedora 42
 ```bash
 sudo dnf update
-sudo dnf install gcc g++ cmake libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel glew-devel freeglut-devel SDL2-devel lz4-devel ffmpeg ffmpeg-free-devel libXxf86vm-devel glm-devel glfw-devel mpv mpv-devel pulseaudio-libs-devel fftw-devel
+sudo dnf install gcc g++ cmake libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel glew-devel freeglut-devel SDL2-devel lz4-devel ffmpeg ffmpeg-free-devel libXxf86vm-devel glm-devel glfw-devel mpv mpv-devel pulseaudio-libs-devel fftw-devel gmp-devel
 ```
 
 ---


### PR DESCRIPTION
Hi, thanks for making this amazing project!

While I was trying to build this project from source I ran into the following error:

```sh
[ 61%] Building CXX object CMakeFiles/linux-wallpaperengine.dir/src/WallpaperEngine/Render/FBOProvider.cpp.o
/home/julian/Repos/linux-wallpaperengine/src/WallpaperEngine/Render/FBOProvider.cpp:2:10: fatal error: gmpxx.h: No such file or directory
    2 | #include <gmpxx.h>
      |          ^~~~~~~~~
compilation terminated.
```

After a little search online I figured out I head to install the `gmp-devel` package for this error to go away, so I thought I could contribute it to the `README.md` here so this doesn't happen to other people.

Sorry for not creating an issue first, I hope the way I'm doing this is fine since I didn't find any contribution guidelines in my quick search for ones.