### PR TITLE
move wayland-protocols and xorg-xrandr to makedepends

### DIFF
--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -8,13 +8,10 @@ arch=('x86_64')
 url="https://github.com/Almamu/linux-wallpaperengine"
 license=('GPL-3.0-only')
 depends=('lz4' 'ffmpeg' 'mpv' 'glfw' 'glew' 'freeglut' 'libpulse' 'libcups' 'at-spi2-core' 'nss' 'libxcomposite' 'libxdamage' 'nspr')
-makedepends=('git' 'cmake' 'sdl2' 'glm')
+makedepends=('git' 'cmake' 'sdl2' 'glm' 'wayland-protocols' 'xorg-xrandr')
 provides=("linux-wallpaperengine")
 source=("${pkgname}::git+https://github.com/Almamu/linux-wallpaperengine.git#branch=main")
 sha512sums=('SKIP')
-optdepends=(
-    'xorg-xrandr: support for X11'
-    'wayland-protocols: support for wayland')
 
 pkgver() {
     cd "$pkgname"


### PR DESCRIPTION
wayland-protocols and xorg-xrandr were not installed before building, causing cmake to silently skip wayland and x11 support.  Moving them to makedepends ensures they are present during the build process so both drivers get compiled in correctly.