### PR TITLE
Fix: Safely enable native EGL support for GLEW on Wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
 find_package(X11)
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
+
 find_package(GLUT REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(SDL2 REQUIRED)
@@ -568,6 +569,10 @@ endif()
 
 if(WAYLAND_SUPPORT_FOUND)
     target_compile_definitions(linux-wallpaperengine-lib PUBLIC ENABLE_WAYLAND)
+endif()
+
+if(WAYLAND_SUPPORT_FOUND AND NOT X11_SUPPORT_FOUND)
+    target_compile_definitions(linux-wallpaperengine-lib PUBLIC GLEW_EGL)
 endif()
 
 target_include_directories(linux-wallpaperengine-lib PUBLIC

--- a/src/WallpaperEngine/Render/Drivers/WaylandOpenGLDriver.cpp
+++ b/src/WallpaperEngine/Render/Drivers/WaylandOpenGLDriver.cpp
@@ -304,8 +304,15 @@ WaylandOpenGLDriver::WaylandOpenGLDriver (ApplicationContext& context, Wallpaper
 	sLog.exception ("Cannot continue...");
     }
 
+    glewExperimental = GL_TRUE;
     if (const GLenum result = glewInit (); result != GLEW_OK) {
-	sLog.error ("Failed to initialize GLEW: ", glewGetErrorString (result));
+	if (result == GLEW_ERROR_NO_GLX_DISPLAY) {
+	    sLog.out ("Failed to initialize GLEW, but continuing with EGL context: No GLX display");
+	} else {
+	    const char* error = reinterpret_cast<const char*>(glewGetErrorString (result));
+	    sLog.error ("Failed to initialize GLEW: ", error ? error : "Unknown error");
+	    sLog.exception ("Cannot continue...");
+	}
     }
 }
 


### PR DESCRIPTION
Added conditional -DGLEW_EGL to CMakeLists.txt. This ensures that GLEW initializes with an EGL context instead of defaulting to GLX only when X11 is disabled and Wayland is enabled. This prevents breaking standard X11/GLX builds while resolving the 'Failed to initialize GLEW: No GLX display' error for native Wayland compositors like Hyprland.

Also refined error handling in WaylandOpenGLDriver.cpp to gracefully continue only if the glewInit failure specifically complains about missing GLX, treating all other initialization errors as fatal.