### PR TITLE
fix(wayland): use BOTTOM layer and honor --disable-mouse for click-through

### DIFF
--- a/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
@@ -116,7 +116,7 @@ WaylandOutputViewport::WaylandOutputViewport (
 void WaylandOutputViewport::setupLS () {
     surface = wl_compositor_create_surface (m_driver->getWaylandContext ()->compositor);
     layerSurface = zwlr_layer_shell_v1_get_layer_surface (
-	m_driver->getWaylandContext ()->layerShell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND,
+	m_driver->getWaylandContext ()->layerShell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM,
 	"linux-wallpaperengine"
     );
 
@@ -125,7 +125,9 @@ void WaylandOutputViewport::setupLS () {
     }
 
     wl_region* region = wl_compositor_create_region (m_driver->getWaylandContext ()->compositor);
-    wl_region_add (region, 0, 0, INT32_MAX, INT32_MAX);
+    if (m_driver->getApp ().getContext ().settings.mouse.enabled) {
+	wl_region_add (region, 0, 0, INT32_MAX, INT32_MAX);
+    }
 
     zwlr_layer_surface_v1_set_size (layerSurface, 0, 0);
     zwlr_layer_surface_v1_set_anchor (
@@ -137,6 +139,7 @@ void WaylandOutputViewport::setupLS () {
     zwlr_layer_surface_v1_add_listener (layerSurface, &layerSurfaceListener, this);
     zwlr_layer_surface_v1_set_exclusive_zone (layerSurface, -1);
     wl_surface_set_input_region (surface, region);
+    wl_region_destroy (region);
     wl_surface_commit (surface);
     wl_display_roundtrip (m_driver->getWaylandContext ()->display);
 


### PR DESCRIPTION
## Problem

On KDE Plasma (Wayland), two issues occur when using `linux-wallpaperengine` as a desktop wallpaper:

1. **Wallpaper disappears after desktop interaction** — Using `ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND` causes the wallpaper surface to be placed *below* Plasma's own desktop surface. After any user interaction (right-click context menu, etc.), KWin repaints the desktop surface on top and the wallpaper disappears behind a black screen, even though the process is still rendering.

2. **`--disable-mouse` doesn't actually pass clicks through** — The input region is unconditionally set to `INT32_MAX × INT32_MAX`, so even with `--disable-mouse`, the surface captures all pointer events and blocks desktop right-click context menus.

## Fix

- **Use `ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM` instead of `BACKGROUND`** — Places the surface above the desktop but below normal windows, which is the correct stacking for a live wallpaper on KDE. This matches how `mpvpaper` handles it.
- **Make the input region conditional on `settings.mouse.enabled`** — When mouse interaction is disabled, the region is left empty so all clicks pass through to the desktop shell.
- **Add missing `wl_region_destroy()`** — Avoids leaking the Wayland region object after `wl_surface_set_input_region()`.

All three changes are in a single file: `WaylandOutputViewport.cpp`.

## Testing

Tested on:
- KDE Plasma 6.6.3 / Wayland
- NVIDIA GeForce RTX 3080
- Bazzite 43

Verified:
- Scene wallpapers render correctly and remain visible after right-click interactions
- Desktop context menus work normally with `--disable-mouse`
- Mouse interaction still works when `--disable-mouse` is NOT used
- No regressions with video wallpapers