### PR TITLE
fix(shaders): auto-fix HLSL implicit vector type truncation

### DIFF
--- a/src/WallpaperEngine/Render/Shaders/GLSLContext.cpp
+++ b/src/WallpaperEngine/Render/Shaders/GLSLContext.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <memory>
+#include <regex>
 
 #include "SPIRV/GlslangToSpv.h"
 #include "glslang/Include/ResourceLimits.h"
@@ -131,40 +132,70 @@ GLSLContext& GLSLContext::get () {
     return *sInstance;
 }
 
+static bool tryParse (
+    const std::string& source, EShLanguage stage, const TBuiltInResource& resources, glslang::TShader& shader
+) {
+    const char* src = source.c_str ();
+    shader.setStrings (&src, 1);
+    shader.setEntryPoint ("main");
+    shader.setEnvInput (glslang::EShSourceGlsl, stage, glslang::EShClientOpenGL, 330);
+    shader.setEnvClient (glslang::EShClientOpenGL, glslang::EShTargetOpenGL_450);
+    shader.setEnvTarget (glslang::EShTargetSpv, glslang::EShTargetSpv_1_5);
+    shader.setAutoMapLocations (true);
+    shader.setAutoMapBindings (true);
+    return shader.parse (&resources, 100, false, EShMsgDefault);
+}
+
 std::pair<std::string, std::string> GLSLContext::toGlsl (const std::string& vertex, const std::string& fragment) {
-    glslang::TShader vertexShader (EShLangVertex);
+    constexpr int maxRetries = 8;
 
-    const char* vertexSource = vertex.c_str ();
-    vertexShader.setStrings (&vertexSource, 1);
-    vertexShader.setEntryPoint ("main");
-    vertexShader.setEnvInput (glslang::EShSourceGlsl, EShLangVertex, glslang::EShClientOpenGL, 330);
-    vertexShader.setEnvClient (glslang::EShClientOpenGL, glslang::EShTargetOpenGL_450);
-    vertexShader.setEnvTarget (glslang::EShTargetSpv, glslang::EShTargetSpv_1_5);
-    vertexShader.setAutoMapLocations (true);
-    vertexShader.setAutoMapBindings (true);
+    // compile vertex shader with type-mismatch retry
+    std::string vertexSource = vertex;
+    std::unique_ptr<glslang::TShader> vertexShader;
 
-    if (!vertexShader.parse (&BuiltInResource, 100, false, EShMsgDefault)) {
-	sLog.error ("GLSL vertex unit parsing Failed: ", vertexShader.getInfoLog ());
+    for (int attempt = 0; attempt <= maxRetries; attempt++) {
+	vertexShader = std::make_unique<glslang::TShader> (EShLangVertex);
+
+	if (tryParse (vertexSource, EShLangVertex, BuiltInResource, *vertexShader)) {
+	    break;
+	}
+
+	std::string errorLog = vertexShader->getInfoLog ();
+
+	if (attempt < maxRetries && fixVectorTypeMismatch (vertexSource, errorLog)) {
+	    sLog.out ("Applied HLSL vector type fix to vertex shader (attempt ", attempt + 1, ")");
+	    continue;
+	}
+
+	sLog.error ("GLSL vertex unit parsing Failed: ", errorLog);
 	return { "", "" };
     }
-    glslang::TShader fragmentShader (EShLangFragment);
 
-    const char* fragmentSource = fragment.c_str ();
-    fragmentShader.setStrings (&fragmentSource, 1);
-    fragmentShader.setEntryPoint ("main");
-    fragmentShader.setEnvInput (glslang::EShSourceGlsl, EShLangFragment, glslang::EShClientOpenGL, 330);
-    fragmentShader.setEnvClient (glslang::EShClientOpenGL, glslang::EShTargetOpenGL_450);
-    fragmentShader.setEnvTarget (glslang::EShTargetSpv, glslang::EShTargetSpv_1_5);
-    fragmentShader.setAutoMapLocations (true);
-    fragmentShader.setAutoMapBindings (true);
+    // compile fragment shader with type-mismatch retry
+    std::string fragmentSource = fragment;
+    std::unique_ptr<glslang::TShader> fragmentShader;
 
-    if (!fragmentShader.parse (&BuiltInResource, 100, false, EShMsgDefault)) {
-	sLog.error ("GLSL fragment unit parsing Failed: ", fragmentShader.getInfoLog ());
+    for (int attempt = 0; attempt <= maxRetries; attempt++) {
+	fragmentShader = std::make_unique<glslang::TShader> (EShLangFragment);
+
+	if (tryParse (fragmentSource, EShLangFragment, BuiltInResource, *fragmentShader)) {
+	    break;
+	}
+
+	std::string errorLog = fragmentShader->getInfoLog ();
+
+	if (attempt < maxRetries && fixVectorTypeMismatch (fragmentSource, errorLog)) {
+	    sLog.out ("Applied HLSL vector type fix to fragment shader (attempt ", attempt + 1, ")");
+	    continue;
+	}
+
+	sLog.error ("GLSL fragment unit parsing Failed: ", errorLog);
 	return { "", "" };
     }
+
     glslang::TProgram program;
-    program.addShader (&vertexShader);
-    program.addShader (&fragmentShader);
+    program.addShader (vertexShader.get ());
+    program.addShader (fragmentShader.get ());
 
     if (!program.link (EShMsgDefault)) {
 	sLog.error ("Program Linking Failed: ", program.getInfoLog ());
@@ -190,6 +221,151 @@ std::pair<std::string, std::string> GLSLContext::toGlsl (const std::string& vert
 
     return { vertexCompiler.compile () + "#if 0\n" + vertex + "\n#endif",
 	     fragmentCompiler.compile () + "#if 0\n" + fragment + "\n#endif" };
+}
+
+bool GLSLContext::fixVectorTypeMismatch (std::string& source, const std::string& errorLog) {
+    // look for: "wrong operand types" with "N-component vector" mismatches
+    const auto wrongPos = errorLog.find ("wrong operand types");
+
+    if (wrongPos == std::string::npos) {
+	return false;
+    }
+
+    // extract line number: find "0:NNN:" before the error
+    auto colonPos = errorLog.rfind (':', wrongPos);
+    if (colonPos == std::string::npos) return false;
+    colonPos = errorLog.rfind (':', colonPos - 1);
+    if (colonPos == std::string::npos) return false;
+
+    // find the line number between "0:" and the next ":"
+    const auto lineNumStart = errorLog.rfind ("0:", colonPos) + 2;
+    const auto lineNumEnd = errorLog.find (':', lineNumStart);
+    if (lineNumEnd == std::string::npos) return false;
+
+    // extract component counts from "N-component vector" patterns
+    const auto firstComp = errorLog.find ("-component vector", wrongPos);
+    if (firstComp == std::string::npos) return false;
+
+    const auto secondComp = errorLog.find ("-component vector", firstComp + 17);
+    if (secondComp == std::string::npos) return false;
+
+    int lineNum, leftComponents, rightComponents;
+
+    try {
+	lineNum = std::stoi (errorLog.substr (lineNumStart, lineNumEnd - lineNumStart));
+	leftComponents = errorLog[firstComp - 1] - '0';
+	rightComponents = errorLog[secondComp - 1] - '0';
+    } catch (...) {
+	return false;
+    }
+
+    sLog.out ("fixVectorTypeMismatch: line=", lineNum, " left=vec", leftComponents, " right=vec", rightComponents);
+
+    if (leftComponents == rightComponents) {
+	return false;
+    }
+
+    // determine which operand needs truncation and to what size
+    const int targetComponents = std::min (leftComponents, rightComponents);
+
+    std::string swizzle;
+    switch (targetComponents) {
+	case 1: swizzle = ".x"; break;
+	case 2: swizzle = ".xy"; break;
+	case 3: swizzle = ".xyz"; break;
+	default: return false;
+    }
+
+    // find the source line
+    size_t lineStart = 0;
+
+    for (int i = 1; i < lineNum; i++) {
+	lineStart = source.find ('\n', lineStart);
+
+	if (lineStart == std::string::npos) {
+	    return false;
+	}
+
+	lineStart++;
+    }
+
+    size_t lineEnd = source.find ('\n', lineStart);
+
+    if (lineEnd == std::string::npos) {
+	lineEnd = source.length ();
+    }
+
+    std::string line = source.substr (lineStart, lineEnd - lineStart);
+
+    // collect all variable names with their component counts from declarations before this line
+    std::map<std::string, int> varComponents;
+    static const std::regex declPattern (
+	R"(\b(?:out|in|uniform|varying|attribute)\s+(vec(\d)|ivec(\d)|float|int|mat\d)\s+(\w+))"
+    );
+
+    for (auto it = std::sregex_iterator (source.begin (), source.begin () + lineStart, declPattern);
+	 it != std::sregex_iterator (); ++it) {
+	const std::string type = (*it)[1].str ();
+	const std::string name = (*it)[4].str ();
+
+	if (type.substr (0, 3) == "vec" || type.substr (0, 4) == "ivec") {
+	    const int components = type.back () - '0';
+	    varComponents[name] = components;
+	} else if (type == "float" || type == "int") {
+	    varComponents[name] = 1;
+	}
+    }
+
+    // find the larger-component variable on the error line and add swizzle
+    bool fixed = false;
+    const int largerComponents = std::max (leftComponents, rightComponents);
+
+    for (const auto& [name, components] : varComponents) {
+	if (components != largerComponents) {
+	    continue;
+	}
+
+	// find this variable name on the error line followed by a space or operator (not .xyz already)
+	size_t varPos = 0;
+
+	while ((varPos = line.find (name, varPos)) != std::string::npos) {
+	    const size_t afterVar = varPos + name.length ();
+
+	    // make sure it's a whole word match
+	    if (varPos > 0 && (std::isalnum (line[varPos - 1]) || line[varPos - 1] == '_')) {
+		varPos = afterVar;
+		continue;
+	    }
+
+	    // skip if already has a swizzle
+	    if (afterVar < line.length () && line[afterVar] == '.') {
+		varPos = afterVar;
+		continue;
+	    }
+
+	    // skip if followed by alphanumeric (part of another identifier)
+	    if (afterVar < line.length () && (std::isalnum (line[afterVar]) || line[afterVar] == '_')) {
+		varPos = afterVar;
+		continue;
+	    }
+
+	    // insert swizzle
+	    line.insert (afterVar, swizzle);
+	    fixed = true;
+	    break;
+	}
+
+	if (fixed) {
+	    break;
+	}
+    }
+
+    if (fixed) {
+	source.replace (lineStart, lineEnd - lineStart, line);
+	sLog.out ("Fixed vector type mismatch on line ", lineNum, ": added ", swizzle, " swizzle");
+    }
+
+    return fixed;
 }
 
 std::unique_ptr<GLSLContext> GLSLContext::sInstance = nullptr;

--- a/src/WallpaperEngine/Render/Shaders/GLSLContext.h
+++ b/src/WallpaperEngine/Render/Shaders/GLSLContext.h
@@ -22,6 +22,16 @@ public:
     [[nodiscard]] static GLSLContext& get ();
 
 private:
+    /**
+     * Attempts to fix HLSL-to-GLSL vector type mismatches by parsing glslang error messages
+     * and adding appropriate swizzle operators to truncate larger vectors.
+     *
+     * @param source The shader source code
+     * @param errorLog The glslang error log
+     * @return true if a fix was applied, false otherwise
+     */
+    static bool fixVectorTypeMismatch (std::string& source, const std::string& errorLog);
+
     static std::unique_ptr<GLSLContext> sInstance;
 };
 } // namespace WallpaperEngine::Render::Shaders


### PR DESCRIPTION
## Summary

HLSL allows implicit truncation in mixed-size vector operations like `float4 * float2`, silently using the `.xy` components. GLSL requires explicit swizzling and rejects the operation with `wrong operand types: no operation '*' exists`.

This adds a retry mechanism to the shader compilation pipeline:

1. If `glslang::TShader::parse()` fails with a "wrong operand types" error involving N-component and M-component vectors, `fixVectorTypeMismatch()` parses the error to extract the line number and component counts.
2. It scans variable declarations before the error line to build a type map, identifies the larger-component variable on the error line, and inserts the appropriate swizzle (`.xy`, `.xyz`, `.x`).
3. Compilation is retried with the patched source (up to 8 retries to handle multiple mismatches in the same shader).

This also extracts `tryParse()` as a reusable helper to reduce code duplication between vertex and fragment shader compilation.

**Backward-compatible**: the fix only activates when compilation would otherwise fail, so shaders that already compile are completely unaffected.

## Test plan

- Fixes Azur Lane (Workshop ID 3326693446) where `iris_follow_cursor.vert` had `v_PointerUV` declared as `vec4` but multiplied by `vec2` scale uniforms
- Tested against 37 scene wallpapers — no regressions