### PR TITLE
fix: Hide passthrough images if all effects are invisible

### DIFF
--- a/src/WallpaperEngine/Render/Objects/CImage.cpp
+++ b/src/WallpaperEngine/Render/Objects/CImage.cpp
@@ -253,9 +253,24 @@ void CImage::setup () {
     // TODO: CHECK ORDER OF THINGS, 2419444134'S ID 27 DEPENDS ON 104'S COMPOSITE_A WHEN OUR LAST RENDER IS ON
     // COMPOSITE_B
     // TODO: SUPPORT PASSTHROUGH (IT'S A SHADER)
-    // passthrough images without effects are bad, do not draw them
-    if (this->m_image.model->passthrough && this->m_image.effects.empty ()) {
-	return;
+    if (this->m_image.model->passthrough) {
+		// passthrough images without effects are bad, do not draw them
+		if(this->m_image.effects.empty ()) {
+			return;
+		}
+
+		// Some have attempted to declare effects with visible set to false.
+		bool allEffectsInvisible = true;
+		for (const auto& cur : this->m_image.effects) {
+			if (cur->visible->value->getBool()) {
+				allEffectsInvisible = false;
+				break;
+			}
+		}
+
+		if (allEffectsInvisible) {
+			return;
+		}
     }
 
     // copy pass to the composite layer


### PR DESCRIPTION
Any images that use passthrough and have no effects are not shown. However, if an image uses passthrough and has effects with all of its visibility properties set to false, it shows the image, even though in this case "no effects" should be treated the same as "all effects are invisible".

This PR resolves that by also not showing passthrough layers if all of the effects are not visible.

While this is more of a band-aid fix as passthrough isn't properly supported, it fixes an edge case issue of some layers using properties until such a proper fix is in place.

Fixes #533.