### PR TITLE
:wrench: use background layer instead of bottom

### DIFF
--- a/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
@@ -116,7 +116,7 @@ WaylandOutputViewport::WaylandOutputViewport (
 void WaylandOutputViewport::setupLS () {
     surface = wl_compositor_create_surface (m_driver->getWaylandContext ()->compositor);
     layerSurface = zwlr_layer_shell_v1_get_layer_surface (
-	m_driver->getWaylandContext ()->layerShell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM,
+	m_driver->getWaylandContext ()->layerShell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND,
 	"linux-wallpaperengine"
     );
 


### PR DESCRIPTION
This PR solves [issue#541](https://github.com/Almamu/linux-wallpaperengine/issues/541), [issue#543](https://github.com/Almamu/linux-wallpaperengine/issues/543), [niri/issue#3843](https://github.com/niri-wm/niri/issues/3843).

Wallpapers should lie in the background layer, rather than bottom layer. Niri's new blur feature reads background from the background layer, which is incompatible with linux-wallpaperengine.