### PR TITLE
fix: GLFWWindowOutput refreshes viewport in all window modes

### DIFF
--- a/src/WallpaperEngine/Render/Drivers/Output/GLFWWindowOutput.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/GLFWWindowOutput.cpp
@@ -54,11 +54,10 @@ void* GLFWWindowOutput::getImageBuffer () const { return nullptr; }
 uint32_t GLFWWindowOutput::getImageBufferSize () const { return 0; }
 
 void GLFWWindowOutput::updateRender () const {
-    if (this->m_context.settings.render.mode != Application::ApplicationContext::NORMAL_WINDOW) {
-	return;
-    }
-
-    // take the size from the driver (default window size)
+    // Track the current framebuffer dimensions regardless of window mode so
+    // runtime resizes (EXPLICIT_WINDOW mode via resizeWindow, WM-initiated
+    // host window resize) re-stretch the scene across the new viewport
+    // instead of cropping the original render at the old size.
     this->m_fullWidth = this->m_driver.getFramebufferSize ().x;
     this->m_fullHeight = this->m_driver.getFramebufferSize ().y;
 


### PR DESCRIPTION
updateRender() early-returned unless mode was NORMAL_WINDOW, so in EXPLICIT_WINDOW (--window XxYxWxH) the viewport stayed at whatever dimensions the output was first constructed with. Calling resizeWindow() later (e.g. from a host WM event) moved the GLFW window but the scene kept rendering at the original viewport, so the host just cropped a fixed-size render.

Drop the mode gate. Viewport now tracks framebuffer size on every updateRender call regardless of mode; scene / video / web wallpapers all stretch across the new viewport immediately.