### PR TITLE
fix(cmake): add $ORIGIN/lib64 to INSTALL_RPATH for kissfft on 64-bit …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ set(TARGET_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output)
 # NOTE: \$ORIGIN must be escaped because CMake treats $VAR as variable expansion.
 # IMPORTANT: This must be set BEFORE any add_executable()/add_library() calls in this directory.
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_INSTALL_RPATH "\$ORIGIN;\$ORIGIN/lib")
+set(CMAKE_INSTALL_RPATH "\$ORIGIN;\$ORIGIN/lib;\$ORIGIN/lib64")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
 add_subdirectory(${CEF_LIBCEF_DLL_WRAPPER_PATH} libcef_dll_wrapper)


### PR DESCRIPTION
kissfft uses GNUInstallDirs, which installs shared libraries to lib64/ on 64-bit Linux systems. The binary's RUNPATH was only set to search $ORIGIN/lib, causing libkissfft-float.so to not be found at runtime after installation to /opt/linux-wallpaperengine/.

Fixes: libkissfft-float.so.131 => not found