### PR TITLE
Fix PulseAudio segfault and resource leaks

### DIFF
--- a/src/WallpaperEngine/Audio/Drivers/Recorders/PulseAudioPlaybackRecorder.cpp
+++ b/src/WallpaperEngine/Audio/Drivers/Recorders/PulseAudioPlaybackRecorder.cpp
@@ -96,6 +96,10 @@ void pa_stream_read_cb (pa_stream* stream, const size_t /*nbytes*/, void* userda
 }
 
 void pa_server_info_cb (pa_context* ctx, const pa_server_info* info, void* userdata) {
+    if (info == nullptr) {
+	return;
+    }
+
     auto* recorder = static_cast<PulseAudioPlaybackRecorder::PulseAudioData*> (userdata);
 
     pa_sample_spec spec;
@@ -131,7 +135,10 @@ void pa_server_info_cb (pa_context* ctx, const pa_server_info* info, void* userd
 
 void pa_context_subscribe_cb (pa_context* ctx, pa_subscription_event_type_t t, uint32_t idx, void* userdata) {
     // sink changes mean re-take the stream
-    pa_context_get_server_info (ctx, &pa_server_info_cb, userdata);
+    pa_operation* o = pa_context_get_server_info (ctx, &pa_server_info_cb, userdata);
+    if (o) {
+	pa_operation_unref (o);
+    }
 }
 
 void pa_context_notify_cb (pa_context* ctx, void* userdata) {
@@ -151,7 +158,11 @@ void pa_context_notify_cb (pa_context* ctx, void* userdata) {
 		}
 
 		// context being ready means to fetch the sink too
-		pa_context_get_server_info (ctx, &pa_server_info_cb, userdata);
+		pa_operation* o2 = pa_context_get_server_info (ctx, &pa_server_info_cb, userdata);
+
+		if (o2) {
+		    pa_operation_unref (o2);
+		}
 
 		break;
 	    }
@@ -196,6 +207,7 @@ PulseAudioPlaybackRecorder::~PulseAudioPlaybackRecorder () {
     free (this->m_captureData.kisscfg);
 
     pa_context_disconnect (this->m_context);
+    pa_context_unref (this->m_context);
     pa_mainloop_free (this->m_mainloop);
 }
 


### PR DESCRIPTION
this fixed an issue i've had for a while, in niri over dms w/ the linux-wallpaperengine plugin. I couldn't use it longer than an hour or two without it just segfaulting out of nowhere.
`
segfault at 30 ip 000064cbe9ec4235 sp 00007ffd36309a00 error 4 in linux-wallpaperengine[1d3235,64cbe9e1b000+575000] likely on CPU 17 (core 11, socket 0))`

if you check /usr/include/pulse/introspect.h:

const char *default_sink_name;   // Offset 0x30 (48 bytes)
^^^So it must be something related to this

`grep -r "default_sink_name" /usr/local/src/linux-wallpaperengine/src`

found: /usr/local/src/linux-wallpaperengine/src/WallpaperEngine/Audio/Drivers/Recorders/PulseAudioPlaybackRecorder.cpp

Then noted the issue in the code.

if info is null in this case, when you run the following code:
`
std::string monitor_name (info->default_sink_name);`

you would be accessing 0x30 since default_sink_name is on offset 0x30

0x30 is nullpage so MMU triggered segfault.

Anyways to summarize:

pa_server_info_cb didn't check null for info, if the audio server returns an error the program will crash. I also [think that pa_operation_unref is necessary ](https://freedesktop.org/software/pulseaudio/doxygen/operation_8h.html?__goaway_challenge=meta-refresh&__goaway_id=e88d0858974d356634a22d29c6040e63&__goaway_referer=https%3A%2F%2Fwww.google.com%2F)

This should resolve potential use-after-free and memory leak issues (allows pulse threads to terminate correctly).

The benefit (atleast to me) has been tangible.

Thanks!