### PR TITLE
Fix: fix error text property parser with "pointsize"

### DIFF
--- a/src/WallpaperEngine/Data/Model/Object.h
+++ b/src/WallpaperEngine/Data/Model/Object.h
@@ -593,7 +593,7 @@ struct TextData {
     /** Font reference from scene (e.g. "fonts/VCR_OSD_MONO.ttf" or "systemfont_arial") */
     std::string font;
     /** Font size in points */
-    float pointsize;
+    UserSettingUniquePtr pointsize;
     /** Bounding box size */
     glm::vec2 size;
     /** Scale (x, y, z) */

--- a/src/WallpaperEngine/Data/Parsers/ObjectParser.cpp
+++ b/src/WallpaperEngine/Data/Parsers/ObjectParser.cpp
@@ -208,7 +208,7 @@ TextUniquePtr ObjectParser::parseText (const JSON& it, const Project& project, O
 	    .script = std::move (script),
 	    .scriptProperties = std::move (scriptProps),
 	    .font = it.optional ("font", std::string ()),
-	    .pointsize = it.optional ("pointsize", 32.0f),
+	    .pointsize = it.user ("pointsize", properties, 32.0f),
 	    .size = it.optional ("size", glm::vec2 (0.0f)),
 	    .scale = it.user ("scale", properties, glm::vec3 (1.0f)),
 	    .color = it.user ("color", properties, glm::vec4 (1.0f)),

--- a/src/WallpaperEngine/Render/Objects/CText.cpp
+++ b/src/WallpaperEngine/Render/Objects/CText.cpp
@@ -179,7 +179,7 @@ unsigned int CText::computeEffectivePixelSize () const {
 	? std::min (1.0f / avgScale, 32.0f)
 	: 1.0f;
     return std::max<unsigned int> (
-	1u, static_cast<unsigned int> (static_cast<float> (m_text.pointsize) * compensate));
+	1u, static_cast<unsigned int> (m_text.pointsize->value->getFloat () * compensate));
 }
 
 void CText::initScriptLayer () {


### PR DESCRIPTION
The "pointsize" property in the TextData struct should be get by using "user“ since it can be defined by user.