### PR TITLE
fix: --clamp argparse missing .append() blocks multi-screen apply

### DIFF
--- a/src/WallpaperEngine/Application/ApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/ApplicationContext.cpp
@@ -392,7 +392,8 @@ void ApplicationContext::loadSettingsFromArgv () {
 	    } else {
 		this->settings.render.window.clamp = flags;
 	    }
-	});
+	})
+	.append ();
 
     auto& performanceGroup = program.add_group ("Performance options");
 


### PR DESCRIPTION
## What

Adds `.append()` to the `--clamp` argparse registration so it accepts the same multi-occurrence usage that `--scaling` already supports.

## Why

Multi-screen mode pairs each `--screen-root` with a per-screen `--scaling` and `--clamp`. `--scaling` is registered with `.append()`, but `--clamp` is not — so passing it twice (once per screen) crashes immediately:

```
$ linux-wallpaperengine \
    --screen-root HDMI-A-1 --scaling fit --clamp clamp --bg <id_a> \
    --screen-root DP-1     --scaling fit --clamp clamp --bg <id_b>
Duplicate argument --clamp. Use ... --help for more information.
```

This makes it impossible to set per-screen clamp behavior in multi-monitor setups; the workaround is to omit `--clamp` entirely and accept the default for every screen.

## Fix

Mirror what `--scaling` already does:

```cpp
.action ([this, &lastScreen] (const std::string& value) -> void {
    // ... unchanged
})
.append ();   // <- added
```

Two-line diff. No behavior change for single-screen invocations.

## Test plan

- Build clean off `main`.
- `--screen-root A --clamp clamp_repeat --bg X --screen-root B --clamp clamp --bg Y` no longer crashes; each screen receives its declared clamp mode (verified against `settings.general.screenClamps`).
- Single-screen `--clamp` still works as before.