### PR TITLE
Tolerate directory properties and missing bool defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,7 +499,8 @@ if(BUILD_TESTING)
         src/WallpaperEngine/Testing/Input/TestingMouseInput.h
         src/WallpaperEngine/Testing/Harnesses/RenderHarness.cpp
         src/WallpaperEngine/Testing/Harnesses/RenderHarness.h
-        src/WallpaperEngine/Testing/Cases/MouseCoordinates.cpp)
+        src/WallpaperEngine/Testing/Cases/MouseCoordinates.cpp
+        src/WallpaperEngine/Testing/Cases/PropertyParser.cpp)
 endif()
 
 add_library(

--- a/src/WallpaperEngine/Data/Parsers/PropertyParser.cpp
+++ b/src/WallpaperEngine/Data/Parsers/PropertyParser.cpp
@@ -26,7 +26,7 @@ PropertySharedPtr PropertyParser::parse (const JSON& it, const std::string& name
     if (type == "scenetexture") {
 	return parseSceneTexture (it, name);
     }
-    if (type == "file") {
+    if (type == "file" || type == "directory") {
 	return parseFile (it, name);
     }
     if (type == "textinput") {
@@ -92,7 +92,7 @@ PropertySharedPtr PropertyParser::parseBoolean (const JSON& it, const std::strin
 	    .name = name,
 	    .text = it.optional<std::string> ("text", ""),
 	},
-	it.require ("value", "Property must have a value")
+	it.optional ("value", false)
     );
 }
 

--- a/src/WallpaperEngine/Testing/Cases/PropertyParser.cpp
+++ b/src/WallpaperEngine/Testing/Cases/PropertyParser.cpp
@@ -1,0 +1,33 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "WallpaperEngine/Data/Parsers/PropertyParser.h"
+#include "WallpaperEngine/Data/Model/Property.h"
+
+using WallpaperEngine::Data::JSON::JSON;
+using WallpaperEngine::Data::Model::DynamicValue;
+using WallpaperEngine::Data::Parsers::PropertyParser;
+
+TEST_CASE ("Bool properties without a value default to false") {
+    const JSON propertyData = {
+	{ "type", "bool" },
+	{ "text", "Enabled" },
+    };
+
+    const auto property = PropertyParser::parse (propertyData, "enabled");
+
+    REQUIRE (property != nullptr);
+    CHECK (property->getType () == DynamicValue::Boolean);
+    CHECK_FALSE (property->getBool ());
+}
+
+TEST_CASE ("Directory properties are parsed as file-like properties") {
+    const JSON propertyData = {
+	{ "type", "directory" },
+	{ "text", "Folder" },
+    };
+
+    const auto property = PropertyParser::parse (propertyData, "folder");
+
+    REQUIRE (property != nullptr);
+    CHECK (property->dump ().find ("folder - file") != std::string::npos);
+}


### PR DESCRIPTION
Relates to #574.

## Summary

This PR addresses the parser-level failures reported while testing Wallpaper Engine visualizer projects in #574.

It keeps the scope intentionally small:

- treat `directory` properties like file-like properties
- default bool properties without an explicit `value` to `false`
- add parser tests for both cases

This does not attempt to solve the broader visualizer/runtime surface such as audio APIs, scripted scene behavior, thumbnails, or other web runtime features. Those should remain separate follow-up work.

## Why

Some Workshop projects contain valid property metadata that currently aborts parsing before the renderer can get to the actual runtime behavior:

- `Unexpected type for property: "directory"`
- `Property must have a value`

Those failures make it harder to distinguish parser compatibility issues from the larger runtime/API gaps tracked around #574.

## Validation

Local validation:

```bash
cmake --build build --target linux-wallpaperengine tests -j$(nproc)
./build/output/tests --reporter compact
git diff --check
```

Result:

- `All tests passed (23 assertions in 9 test cases)`
- `--list-properties` against Workshop item `1081733658` emitted the visualizer property list without the previous parser signatures (`Unexpected type for property`, `Property must have a value`) under a time-boxed smoke test.
