### PR TITLE
feat(wayland): add --layer CLI flag to choose wlr-layer-shell layer

### DIFF
--- a/src/WallpaperEngine/Application/ApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/ApplicationContext.cpp
@@ -394,6 +394,29 @@ void ApplicationContext::loadSettingsFromArgv () {
 	    }
 	});
 
+    backgroundGroup.add_argument ("--layer")
+	.help (
+	    "Wayland-only: which wlr-layer-shell layer to anchor the wallpaper to "
+	    "(background, bottom, top, overlay). Default: bottom. "
+	    "Use 'background' on niri to pair with the `place-within-backdrop` layer-rule, "
+	    "otherwise the wallpaper will be cloned to every workspace in the overview."
+	)
+	.choices ("background", "bottom", "top", "overlay")
+	.default_value (std::string ("bottom"))
+	.action ([this] (const std::string& value) -> void {
+	    if (value == "background") {
+		this->settings.render.wayland.layer = WAYLAND_LAYER_BACKGROUND;
+	    } else if (value == "bottom") {
+		this->settings.render.wayland.layer = WAYLAND_LAYER_BOTTOM;
+	    } else if (value == "top") {
+		this->settings.render.wayland.layer = WAYLAND_LAYER_TOP;
+	    } else if (value == "overlay") {
+		this->settings.render.wayland.layer = WAYLAND_LAYER_OVERLAY;
+	    } else {
+		sLog.exception ("Invalid wlr-layer-shell layer: ", value);
+	    }
+	});
+
     auto& performanceGroup = program.add_group ("Performance options");
 
     performanceGroup.add_argument ("-f", "--fps")

--- a/src/WallpaperEngine/Application/ApplicationContext.h
+++ b/src/WallpaperEngine/Application/ApplicationContext.h
@@ -40,6 +40,18 @@ public:
 	EXPLICIT_WINDOW = 2,
     };
 
+    /**
+     * Wayland-only: which wlr-layer-shell layer to anchor the wallpaper surface to.
+     * Different compositors treat layers differently; e.g. niri's
+     * `place-within-backdrop` layer-rule only applies to BACKGROUND surfaces.
+     */
+    enum WAYLAND_LAYER {
+	WAYLAND_LAYER_BACKGROUND = 0,
+	WAYLAND_LAYER_BOTTOM = 1,
+	WAYLAND_LAYER_TOP = 2,
+	WAYLAND_LAYER_OVERLAY = 3,
+    };
+
     struct PlaylistSettings {
 	uint32_t delayMinutes = 60;
 	std::string mode = "timer";
@@ -110,6 +122,11 @@ public:
 		TextureFlags clamp;
 		WallpaperEngine::Render::WallpaperState::TextureUVsScaling scalingMode;
 	    } window;
+
+	    struct {
+		/** Which wlr-layer-shell layer to use for desktop backgrounds */
+		WAYLAND_LAYER layer;
+	    } wayland;
 	} render;
 
 	/**
@@ -170,6 +187,9 @@ public:
                 .geometry = {},
                 .clamp = TextureFlags_ClampUVs,
                 .scalingMode = WallpaperEngine::Render::WallpaperState::TextureUVsScaling::DefaultUVs,
+            },
+            .wayland = {
+                .layer = WAYLAND_LAYER_BOTTOM,
             },
         },
         .audio = {

--- a/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
@@ -115,8 +115,26 @@ WaylandOutputViewport::WaylandOutputViewport (
 
 void WaylandOutputViewport::setupLS () {
     surface = wl_compositor_create_surface (m_driver->getWaylandContext ()->compositor);
+
+    zwlr_layer_shell_v1_layer wlrLayer;
+    switch (m_driver->getApp ().getContext ().settings.render.wayland.layer) {
+	case WallpaperEngine::Application::ApplicationContext::WAYLAND_LAYER_BACKGROUND:
+	    wlrLayer = ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
+	    break;
+	case WallpaperEngine::Application::ApplicationContext::WAYLAND_LAYER_TOP:
+	    wlrLayer = ZWLR_LAYER_SHELL_V1_LAYER_TOP;
+	    break;
+	case WallpaperEngine::Application::ApplicationContext::WAYLAND_LAYER_OVERLAY:
+	    wlrLayer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
+	    break;
+	case WallpaperEngine::Application::ApplicationContext::WAYLAND_LAYER_BOTTOM:
+	default:
+	    wlrLayer = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+	    break;
+    }
+
     layerSurface = zwlr_layer_shell_v1_get_layer_surface (
-	m_driver->getWaylandContext ()->layerShell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM,
+	m_driver->getWaylandContext ()->layerShell, surface, output, wlrLayer,
 	"linux-wallpaperengine"
     );
 

--- a/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
@@ -147,6 +147,14 @@ void WaylandOutputViewport::setupLS () {
 	wl_region_add (region, 0, 0, INT32_MAX, INT32_MAX);
     }
 
+    // Mark the surface as fully opaque so the compositor can skip rendering
+    // anything below it and avoid alpha-blending. Wallpapers are by definition
+    // the bottommost visible content, so this is always a win.
+    wl_region* opaqueRegion = wl_compositor_create_region (m_driver->getWaylandContext ()->compositor);
+    wl_region_add (opaqueRegion, 0, 0, INT32_MAX, INT32_MAX);
+    wl_surface_set_opaque_region (surface, opaqueRegion);
+    wl_region_destroy (opaqueRegion);
+
     zwlr_layer_surface_v1_set_size (layerSurface, 0, 0);
     zwlr_layer_surface_v1_set_anchor (
 	layerSurface,


### PR DESCRIPTION
## Summary

- Adds `--layer {background,bottom,top,overlay}` CLI flag for desktop background mode (Wayland only). Default remains `bottom` so existing setups are unaffected.
- Marks the layer-shell surface as fully opaque via `wl_surface_set_opaque_region` (separate commit, opportunistic perf cleanup).

Fixes #584.

## Motivation

`WaylandOutputViewport::setupLS()` hardcodes the wallpaper surface to `ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM`. This conflicts with [niri](https://github.com/YaLTeR/niri)'s `place-within-backdrop` layer-rule, which only applies to `background` layer surfaces. Without the rule, niri clones layer-shell surfaces into every workspace card in the overview — invisible with a static wallpaper, but very visible (and animated) with WPE Scene/video wallpapers.

After this change, niri users can do:

```
linux-wallpaperengine --screen-root DP-1 --bg 12345 --layer background
```

```kdl
layer-rule {
    match namespace="^linux-wallpaperengine$"
    place-within-backdrop true
}
```

and get one shared backdrop instead of N duplicates.

`background` is also the semantically intended layer for wallpapers per the wlr-layer-shell protocol; `swww`/`swaybg`/etc. already anchor there by default.

## Test plan

- [x] Builds on Wayland (Arch/CachyOS, clang).
- [x] Without `--layer`: behavior identical to upstream (anchors to `bottom`, verified via `niri msg layers`).
- [x] With `--layer background`: surface appears on `Background` (verified via `niri msg layers`) and the wallpaper renders correctly under niri.
- [x] With `--layer background` + niri's `place-within-backdrop` layer-rule: wallpaper renders once as a shared backdrop in overview, instead of being cloned to every workspace card.
- [x] Animated Scene wallpaper plays correctly on all layer choices.
- [x] No regression in `--window` or non-Wayland (`render.mode != DESKTOP_BACKGROUND`) paths — `--layer` is only consulted in `setupLS()`.

## Commits

1. `feat(wayland): add --layer CLI flag to choose wlr-layer-shell layer` — the actual fix.
2. `perf(wayland): mark wallpaper surface as fully opaque` — orthogonal cleanup; can be dropped if you'd prefer a strictly-scoped PR.