### PR TITLE
fix: normalize IVec3 image color to 0-1 range in ObjectParser

### DIFF
--- a/src/WallpaperEngine/Data/Parsers/ObjectParser.cpp
+++ b/src/WallpaperEngine/Data/Parsers/ObjectParser.cpp
@@ -298,12 +298,8 @@ ObjectParser::parseImage (const JSON& it, const Project& project, ObjectData bas
 	}
     );
 
-    // color should be a vec4 for alpha, but it's read as vec3
-    if (result->color->value->getType () == DynamicValue::UnderlyingType::Vec3) {
-	result->color->value->update (glm::vec4 (result->color->value->getVec3 (), 1.0f));
-    } else if (result->color->value->getType () == DynamicValue::UnderlyingType::IVec3) {
-	result->color->value->update (glm::vec4 (result->color->value->getIVec3 (), 255));
-    }
+    // color may arrive as vec3 or ivec3; normalize to a vec4 with full alpha
+    widenColorToVec4 (*result->color->value);
 
     bindScriptContext (result->scale, result->id, result->name, "scale");
     bindScriptContext (result->angles, result->id, result->name, "angles");


### PR DESCRIPTION
## Summary

`ObjectParser::parseImage()` widened `IVec3` (0–255) color values into a `vec4` without normalizing them, so OpenGL shaders received raw 0–255 components instead of the expected 0.0–1.0 range (`glUniform4f`).

This reuses the existing `widenColorToVec4()` helper — already used for the base color path and consistent with `parseParticleInitializer()` — which both fixes the normalization and removes the duplicated inline block.

## Verification

- Compiles cleanly with the project's build flags (`-Werror`).

Fixes #540