### PR TITLE
ci: add Clang build job to catch Clang-only warnings

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -74,6 +74,37 @@ jobs:
         run: ${{github.workspace}}/build/output/tests
 
 
+  build-clang:
+    # Build with Clang to catch warnings (e.g. unused-private-field,
+    # unused-lambda-capture) that only Clang reports under -Wall -Werror and
+    # that the GCC jobs miss. See issue #595 and the regressions fixed in #558.
+    needs: tests
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        build_type: [Release]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.build_type }}
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get -y install clang libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev libglew-dev freeglut3-dev libsdl2-dev liblz4-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libxxf86vm-dev libglm-dev libglfw3-dev libmpv-dev mpv libmpv2 libpulse-dev libpulse0 libfftw3-dev libfreetype-dev wayland-scanner++ wayland-protocols libwayland-dev libwayland-egl-backend-dev
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+
+
   build-x11:
     needs: tests
     strategy:


### PR DESCRIPTION
## Summary

The existing CMake CI jobs build with GCC. The project already compiles its own targets with `-Wall -Werror`, but a number of warnings — e.g. `-Wunused-private-field` and `-Wunused-lambda-capture` — are only reported by Clang, so they went unnoticed until the cleanup in #558.

This adds a `build-clang` job to `.github/workflows/cmake.yml` that builds a Release configuration with `clang`/`clang++` (X11 + Wayland enabled), so Clang-only warnings are caught on every push and pull request. No source or build-system changes are needed: the existing `-Wall -Werror` already turns these warnings into errors under Clang.

## Verification

- Built the full project locally with `clang`/`clang++` (Release, `-Wall -Werror`): the library and executable compile cleanly; the only warnings come from third-party submodules (kissfft/quickjs), which are not built with the project's warning flags.

Fixes #595