### PR TITLE
fix: mute video wallpapers when --silent is used

### DIFF
--- a/src/WallpaperEngine/Render/Wallpapers/CVideo.cpp
+++ b/src/WallpaperEngine/Render/Wallpapers/CVideo.cpp
@@ -25,7 +25,10 @@ CVideo::CVideo (
 	this->getContext (), this->CWallpaper::getWallpaperTexture (), videopath, 64, 64,
 	this->CWallpaper::getWallpaperFramebuffer ()
     );
-    this->m_player->setVolume (this->getContext ().getApp ().getContext ().settings.audio.volume * 100.0 / 128.0);
+    // --silent disables audio (audio.enabled = false) and must mute video wallpapers too;
+    // a volume of 0 mutes the mpv backend (matching what --volume 0 already does).
+    const auto& audioSettings = this->getContext ().getApp ().getContext ().settings.audio;
+    this->m_player->setVolume (audioSettings.enabled ? audioSettings.volume * 100.0 / 128.0 : 0.0);
     // make sure the video has at least one usage marked, this ensures the video plays
     this->m_player->incrementUsageCount ();
 }


### PR DESCRIPTION
## Summary

`--silent` sets `audio.enabled = false`, but `CVideo` always initialised the mpv player with the configured volume, so video (mpv) wallpapers kept playing audio. Only `--volume 0` muted them (as reported in #482).

This honours `audio.enabled` when setting the initial mpv volume, so `--silent` sets the volume to 0 and mutes video wallpapers too — matching the `--volume 0` behaviour.

## Verification

- Built locally and A/B tested with a video (mpv) wallpaper: with the same output volume, audio plays without `--silent` and is fully silent with `--silent`. Confirmed the volume sent to the mpv backend is `0` under `--silent` (vs the configured volume otherwise).

Fixes #482