### PR TITLE
refactor: load scene-script builtins from a generated header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,22 @@ set_target_properties(ceflib
 ADD_LOGICAL_TARGET(libcef_lib "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
 PRINT_CEF_CONFIG()
 
+# Embed scene-script builtins (builtins.js) into a generated header, so the JS can
+# live in its own file (lint/syntax-highlight friendly) instead of an inline literal.
+# Added to the global include_directories so both the library and the tests target
+# (which recompiles the common sources) can find the generated header.
+set(WPENGINE_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(WPENGINE_BUILTINS_JS "${CMAKE_CURRENT_SOURCE_DIR}/src/WallpaperEngine/Scripting/resources/builtins.js")
+file(READ "${WPENGINE_BUILTINS_JS}" WPENGINE_SCRIPT_BUILTINS)
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/WallpaperEngine/Scripting/resources/Builtins.generated.h.in"
+    "${WPENGINE_GENERATED_DIR}/WallpaperEngine/Scripting/Builtins.generated.h"
+    @ONLY)
+# re-run configuration (regenerating the header) whenever the .js changes
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${WPENGINE_BUILTINS_JS}")
+
 include_directories(
+    ${WPENGINE_GENERATED_DIR}
     src
     src/External/glslang-WallpaperEngine
     src/External/SPIRV-Cross-WallpaperEngine

--- a/src/WallpaperEngine/Scripting/ScriptEngine.cpp
+++ b/src/WallpaperEngine/Scripting/ScriptEngine.cpp
@@ -13,6 +13,7 @@
 #include "WallpaperEngine/Render/CObject.h"
 #include "WallpaperEngine/Render/Objects/CSound.h"
 #include "WallpaperEngine/Render/Wallpapers/CScene.h"
+#include "WallpaperEngine/Scripting/Builtins.generated.h"
 #include "quickjs.h"
 
 #include <algorithm>
@@ -442,27 +443,10 @@ void ScriptEngine::installBuiltins () {
 	return;
     }
 
-    static constexpr const char* builtins = R"JS(
-globalThis.__intervals = Object.create(null);
-globalThis.localStorage = globalThis.localStorage || {
-  __data: Object.create(null),
-  get(key) {
-    key = String(key);
-    return Object.prototype.hasOwnProperty.call(this.__data, key) ? this.__data[key] : null;
-  },
-  set(key, value) { this.__data[String(key)] = String(value); },
-  remove(key) { delete this.__data[String(key)]; },
-  clear() { this.__data = Object.create(null); }
-};
-globalThis.MediaPlaybackEvent = globalThis.MediaPlaybackEvent || {
-  PLAYBACK_STOPPED: 0,
-  PLAYBACK_PLAYING: 1,
-  PLAYBACK_PAUSED: 2
-};
-)JS";
-
-    JSValue result
-	= JS_Eval (this->m_context, builtins, strlen (builtins), "<scene-script-builtins>", JS_EVAL_TYPE_GLOBAL);
+    JSValue result = JS_Eval (
+	this->m_context, SCENE_SCRIPT_BUILTINS, strlen (SCENE_SCRIPT_BUILTINS), "<scene-script-builtins>",
+	JS_EVAL_TYPE_GLOBAL
+    );
     if (JS_IsException (result)) {
 	logJSException (this->m_context, "installBuiltins");
     }

--- a/src/WallpaperEngine/Scripting/resources/Builtins.generated.h.in
+++ b/src/WallpaperEngine/Scripting/resources/Builtins.generated.h.in
@@ -1,0 +1,7 @@
+// This file is auto-generated from builtins.js by CMake (configure_file). Do not edit.
+#pragma once
+
+namespace WallpaperEngine::Scripting {
+inline constexpr const char* SCENE_SCRIPT_BUILTINS = R"JS(
+@WPENGINE_SCRIPT_BUILTINS@)JS";
+} // namespace WallpaperEngine::Scripting

--- a/src/WallpaperEngine/Scripting/resources/builtins.js
+++ b/src/WallpaperEngine/Scripting/resources/builtins.js
@@ -1,0 +1,16 @@
+globalThis.__intervals = Object.create(null);
+globalThis.localStorage = globalThis.localStorage || {
+  __data: Object.create(null),
+  get(key) {
+    key = String(key);
+    return Object.prototype.hasOwnProperty.call(this.__data, key) ? this.__data[key] : null;
+  },
+  set(key, value) { this.__data[String(key)] = String(value); },
+  remove(key) { delete this.__data[String(key)]; },
+  clear() { this.__data = Object.create(null); }
+};
+globalThis.MediaPlaybackEvent = globalThis.MediaPlaybackEvent || {
+  PLAYBACK_STOPPED: 0,
+  PLAYBACK_PLAYING: 1,
+  PLAYBACK_PAUSED: 2
+};


### PR DESCRIPTION
Fixes #592.

## Summary

The scene-script JS builtins (the `localStorage`, `MediaPlaybackEvent` and `__intervals` shims installed into the QuickJS global) were embedded as an inline `R"JS(...)JS"` literal in `ScriptEngine.cpp`. This moves the JS into its own `src/WallpaperEngine/Scripting/resources/builtins.js` and embeds it at build time through a CMake-generated header (`configure_file`), so the script can be edited, linted and syntax-highlighted on its own instead of living inside a C++ string literal.

Most of the original scope of #592 (the `Vec2`/`Vec3`/`WEColor`/`WEMath` definitions, module wrappers, etc.) was already addressed by #599, which moved that logic into native C++ adapters/modules. The `builtins` block was the remaining inline JS, and this change also establishes a small, reusable embed-at-build-time pattern for any future embedded resources.

## Notes

- No behaviour change: the embedded string is byte-identical to the previous literal.
- The header is generated into the build tree (not committed); CMake re-runs configuration when `builtins.js` changes.

## Verification

- Builds cleanly with both GCC and Clang.
- Ran a scene wallpaper; the builtins install with no JS exceptions.