### PR TITLE
fix: always parse space-separated colors as normalized floats

### DIFF
--- a/src/WallpaperEngine/Data/Builders/ColorBuilder.cpp
+++ b/src/WallpaperEngine/Data/Builders/ColorBuilder.cpp
@@ -55,13 +55,6 @@ WallpaperEngine::Data::Builders::ColorBuilder::parse (const std::string& value, 
 	throw std::invalid_argument ("Invalid color value");
     }
 
-    if (copy.find ('.') == std::string::npos) {
-	const auto final = vectorSize == 3 ? glm::ivec4 (VectorBuilder::parse<glm::ivec3> (copy), alpha * 255)
-					   : VectorBuilder::parse<glm::ivec4> (copy);
-
-	return { final.r / 255.0f, final.g / 255.0f, final.b / 255.0f, final.a / 255.0f };
-    }
-
     return Model::Color (
 	vectorSize == 3 ? glm::vec4 (VectorBuilder::parse<glm::vec3> (copy), alpha)
 			: VectorBuilder::parse<glm::vec4> (copy)


### PR DESCRIPTION
WE's color format uses normalized floats (0.0-1.0) for all space/comma-separated values. The previous heuristic treated values without a decimal point as byte-encoded integers (0-255), causing colors like ```1 0 0``` to be parsed as (1/255, 0, 0) instead of (1, 0, 0).

This affected user-property color defaults and any inline color value written without a decimal point, such as ```1 0.65 0.69``` parsing correctly while ```1 0 0``` did not.

Hex colors (```#rrggbb```) are byte-encoded and handled separately; that path is unchanged.

Fixes color rendering for text objects using color user-properties.