### PR TITLE
fix: use resolved object size for effect FBO creation

### DIFF
--- a/src/WallpaperEngine/Render/Objects/CImage.cpp
+++ b/src/WallpaperEngine/Render/Objects/CImage.cpp
@@ -1130,6 +1130,9 @@ void CImage::updateScreenSpacePosition () {
 const Image& CImage::getImage () const { return this->m_image; }
 
 glm::vec2 CImage::getSize () const {
+    if (this->m_size.x > 0.0f && this->m_size.y > 0.0f) {
+	return this->m_size;
+    }
     if (this->m_texture == nullptr) {
 	return this->getImage ().size;
     }


### PR DESCRIPTION
```CImage::getSize()``` returns texture dimensions once a texture is set, but effect FBOs were created by calling ```getSize()``` after texture detection, yielding FBO dimensions based on the base texture size rather than the object's declared size.

For objects like solid layers where the base texture is much smaller than the declared object size, this caused all effect FBOs to be created at the wrong size, resulting in content rendering at a fraction of the intended size (e.g. 32x32 instead of 256x256).

Fix by using m_size, which is set from the correctly resolved object size before texture detection runs.