### PR TITLE
feat: pause wallpaper on battery power to save laptop power

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,8 @@ set(COMMON_SOURCES
 
     src/WallpaperEngine/Render/Drivers/Detectors/FullScreenDetector.cpp
     src/WallpaperEngine/Render/Drivers/Detectors/FullScreenDetector.h
+    src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.cpp
+    src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.h
 
     src/WallpaperEngine/Render/Drivers/Output/Output.cpp
     src/WallpaperEngine/Render/Drivers/Output/Output.h

--- a/src/WallpaperEngine/Application/ApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/ApplicationContext.cpp
@@ -498,6 +498,11 @@ void ApplicationContext::loadSettingsFromArgv () {
 	.flag ()
 	.action ([this] (const std::string& value) -> void { this->settings.render.pauseOnFullscreen = false; });
 
+    performanceGroup.add_argument ("--no-pause-on-battery")
+	.help ("Prevents the background pausing while the system is running on battery power (on by default to save power on laptops)")
+	.flag ()
+	.action ([this] (const std::string& value) -> void { this->settings.render.pauseOnBattery = false; });
+
     performanceGroup.add_argument ("--fullscreen-pause-only-active")
 	.help ("Wayland only: pause only when a fullscreen window is active (activated)")
 	.flag ()

--- a/src/WallpaperEngine/Application/ApplicationContext.h
+++ b/src/WallpaperEngine/Application/ApplicationContext.h
@@ -115,6 +115,8 @@ public:
 	    int maximumFPS;
 	    /** Indicates if pausing should happen when something goes fullscreen */
 	    bool pauseOnFullscreen;
+	    /** Indicates if pausing should happen while the system is running on battery power */
+	    bool pauseOnBattery;
 	    /**
 	     * Wayland-only: if true, only consider fullscreen toplevels that are also activated.
 	     * Useful for compositors with "virtual" fullscreen windows (e.g. scrollable tiling).
@@ -201,6 +203,7 @@ public:
             .mode = NORMAL_WINDOW,
             .maximumFPS = 30,
             .pauseOnFullscreen = true,
+            .pauseOnBattery = true,
             .pauseOnFullscreenOnlyWhenActive = false,
             .fullscreenPauseIgnoreAppIds = {},
             .debug = {

--- a/src/WallpaperEngine/Application/WallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/WallpaperApplication.cpp
@@ -684,6 +684,7 @@ void WallpaperApplication::setupOutput () {
     );
     this->m_fullScreenDetector
 	= sVideoFactories.createFullscreenDetector (XDG_SESSION_TYPE, this->m_context, *this->m_videoDriver);
+    this->m_batteryDetector = std::make_unique<Render::Drivers::Detectors::BatteryDetector> (this->m_context);
 }
 
 void WallpaperApplication::setupAudio () {
@@ -858,7 +859,9 @@ void WallpaperApplication::render () {
 
     if (this->m_isPaused) {
 	usleep (FULLSCREEN_CHECK_WAIT_TIME);
-	if (this->m_fullScreenDetector->anythingFullscreen () && this->m_context.state.general.keepRunning) {
+	if ((this->m_fullScreenDetector->anythingFullscreen ()
+	     || (this->m_context.settings.render.pauseOnBattery && this->m_batteryDetector->isOnBattery ()))
+	    && this->m_context.state.general.keepRunning) {
 	    return;
 	}
 	m_renderContext->setPause (false);
@@ -928,7 +931,9 @@ void WallpaperApplication::render () {
 	}
 #endif /* DEMOMODE */
 	// check for fullscreen windows and wait until there's none fullscreen
-	if (this->m_fullScreenDetector->anythingFullscreen () && this->m_context.state.general.keepRunning) {
+	if ((this->m_fullScreenDetector->anythingFullscreen ()
+	     || (this->m_context.settings.render.pauseOnBattery && this->m_batteryDetector->isOnBattery ()))
+	    && this->m_context.state.general.keepRunning) {
 	    this->m_isPaused = true;
 	    this->m_pauseStart = std::chrono::steady_clock::now ();
 

--- a/src/WallpaperEngine/Application/WallpaperApplication.h
+++ b/src/WallpaperEngine/Application/WallpaperApplication.h
@@ -8,6 +8,7 @@
 
 #include "WallpaperEngine/Render/CWallpaper.h"
 #include "WallpaperEngine/Render/Drivers/Detectors/FullScreenDetector.h"
+#include "WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.h"
 #include "WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.h"
 #include "WallpaperEngine/Render/Drivers/Output/GLFWWindowOutput.h"
 #include "WallpaperEngine/Render/RenderContext.h"
@@ -174,6 +175,7 @@ private:
     std::unique_ptr<WallpaperEngine::Render::RenderContext> m_renderContext = nullptr;
     std::unique_ptr<WallpaperEngine::Render::Drivers::VideoDriver> m_videoDriver = nullptr;
     std::unique_ptr<WallpaperEngine::Render::Drivers::Detectors::FullScreenDetector> m_fullScreenDetector = nullptr;
+    std::unique_ptr<WallpaperEngine::Render::Drivers::Detectors::BatteryDetector> m_batteryDetector = nullptr;
     std::unique_ptr<WallpaperEngine::WebBrowser::WebBrowserContext> m_browserContext = nullptr;
     std::unique_ptr<WallpaperEngine::Media::MediaSource> m_mediaSource = nullptr;
     std::mt19937 m_playlistRng { std::random_device {}() };

--- a/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.cpp
@@ -1,0 +1,51 @@
+#include "BatteryDetector.h"
+#include "WallpaperEngine/Logging/Log.h"
+
+#include <fstream>
+#include <string>
+
+using namespace WallpaperEngine;
+using namespace WallpaperEngine::Render::Drivers::Detectors;
+
+BatteryDetector::BatteryDetector (Application::ApplicationContext& appContext) : m_applicationContext (appContext) {}
+
+Application::ApplicationContext& BatteryDetector::getApplicationContext () const { return this->m_applicationContext; }
+
+bool BatteryDetector::isOnBattery () {
+    const auto now = std::chrono::steady_clock::now ();
+
+    // throttle the sysfs read: reuse the cached value if less than 5 seconds have passed
+    if (std::chrono::duration_cast<std::chrono::seconds> (now - this->m_lastCheckTime).count () < 5) {
+	return this->m_lastBatteryStatus;
+    }
+
+    this->m_lastCheckTime = now;
+
+    // different platforms/kernels expose the AC adapter under different names
+    std::ifstream file ("/sys/class/power_supply/AC/online");
+    if (!file.is_open ()) {
+	file.open ("/sys/class/power_supply/ACAD/online");
+    }
+    if (!file.is_open ()) {
+	file.open ("/sys/class/power_supply/ADP1/online");
+    }
+
+    if (file.is_open ()) {
+	std::string status;
+	std::getline (file, status);
+	// "0" means the AC adapter is offline, so we are running on battery
+	this->m_lastBatteryStatus = (status == "0");
+
+	if (this->m_lastBatteryStatus != this->m_lastLoggedStatus) {
+	    sLog.out ("[BATTERY] Power source changed to: ", this->m_lastBatteryStatus ? "Battery" : "AC");
+	    this->m_lastLoggedStatus = this->m_lastBatteryStatus;
+	}
+
+	return this->m_lastBatteryStatus;
+    }
+
+    // if no AC adapter file exists we cannot tell, so assume we are on AC and keep rendering
+    sLog.error ("[BATTERY] Power source file not found, assuming AC power");
+    this->m_lastBatteryStatus = false;
+    return this->m_lastBatteryStatus;
+}

--- a/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.cpp
@@ -1,8 +1,10 @@
 #include "BatteryDetector.h"
 #include "WallpaperEngine/Logging/Log.h"
 
+#include <filesystem>
 #include <fstream>
 #include <string>
+#include <system_error>
 
 using namespace WallpaperEngine;
 using namespace WallpaperEngine::Render::Drivers::Detectors;
@@ -21,20 +23,44 @@ bool BatteryDetector::isOnBattery () {
 
     this->m_lastCheckTime = now;
 
-    // different platforms/kernels expose the AC adapter under different names
-    std::ifstream file ("/sys/class/power_supply/AC/online");
-    if (!file.is_open ()) {
-	file.open ("/sys/class/power_supply/ACAD/online");
-    }
-    if (!file.is_open ()) {
-	file.open ("/sys/class/power_supply/ADP1/online");
+    // the AC adapter name varies between vendors/kernels/drivers, so instead of
+    // hardcoding names we enumerate every power supply and look at the ones reporting
+    // type "Mains" (the standard recommended pattern on Linux)
+    bool foundPowerSource = false;
+    bool onBattery = true;
+
+    std::error_code ec;
+    const std::filesystem::directory_iterator end {};
+    for (std::filesystem::directory_iterator it ("/sys/class/power_supply", ec); !ec && it != end; it.increment (ec)) {
+	std::ifstream typeFile (it->path () / "type");
+	if (!typeFile.is_open ()) {
+	    continue;
+	}
+
+	std::string type;
+	std::getline (typeFile, type);
+	if (type != "Mains") {
+	    continue;
+	}
+
+	std::ifstream onlineFile (it->path () / "online");
+	if (!onlineFile.is_open ()) {
+	    continue;
+	}
+
+	std::string online;
+	std::getline (onlineFile, online);
+
+	foundPowerSource = true;
+	// "1" means this AC adapter is plugged in, so we are not on battery
+	if (online == "1") {
+	    onBattery = false;
+	    break;
+	}
     }
 
-    if (file.is_open ()) {
-	std::string status;
-	std::getline (file, status);
-	// "0" means the AC adapter is offline, so we are running on battery
-	this->m_lastBatteryStatus = (status == "0");
+    if (foundPowerSource) {
+	this->m_lastBatteryStatus = onBattery;
 
 	if (this->m_lastBatteryStatus != this->m_lastLoggedStatus) {
 	    sLog.out ("[BATTERY] Power source changed to: ", this->m_lastBatteryStatus ? "Battery" : "AC");
@@ -44,8 +70,14 @@ bool BatteryDetector::isOnBattery () {
 	return this->m_lastBatteryStatus;
     }
 
-    // if no AC adapter file exists we cannot tell, so assume we are on AC and keep rendering
-    sLog.error ("[BATTERY] Power source file not found, assuming AC power");
+    // no AC adapter was found (e.g. a desktop without a "Mains" supply); we cannot tell,
+    // so assume we are on AC and keep rendering. log this only once to avoid spamming the
+    // output on every cache refresh
+    if (!this->m_missingPowerSourceLogged) {
+	sLog.out ("[BATTERY] No AC power source found in /sys/class/power_supply, assuming AC power");
+	this->m_missingPowerSourceLogged = true;
+    }
+
     this->m_lastBatteryStatus = false;
     return this->m_lastBatteryStatus;
 }

--- a/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.h
+++ b/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.h
@@ -21,5 +21,6 @@ private:
     std::chrono::steady_clock::time_point m_lastCheckTime;
     bool m_lastBatteryStatus = false;
     bool m_lastLoggedStatus = false;
+    bool m_missingPowerSourceLogged = false;
 };
 } // namespace WallpaperEngine::Render::Drivers::Detectors

--- a/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.h
+++ b/src/WallpaperEngine/Render/Drivers/Detectors/BatteryDetector.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "WallpaperEngine/Application/ApplicationContext.h"
+#include <chrono>
+
+namespace WallpaperEngine::Render::Drivers::Detectors {
+class BatteryDetector {
+public:
+    explicit BatteryDetector (Application::ApplicationContext& appContext);
+    virtual ~BatteryDetector () = default;
+
+    /**
+     * @return true if the system is currently running on battery power
+     */
+    [[nodiscard]] virtual bool isOnBattery ();
+
+    [[nodiscard]] Application::ApplicationContext& getApplicationContext () const;
+
+private:
+    Application::ApplicationContext& m_applicationContext;
+    std::chrono::steady_clock::time_point m_lastCheckTime;
+    bool m_lastBatteryStatus = false;
+    bool m_lastLoggedStatus = false;
+};
+} // namespace WallpaperEngine::Render::Drivers::Detectors


### PR DESCRIPTION
## What

   Adds battery-aware pausing so the wallpaper stops rendering while a laptop is running on battery, and resumes once AC power is restored.

   ## How

   - New `BatteryDetector` reads the AC adapter state from sysfs (`/sys/class/power_supply/{AC,ACAD,ADP1}/online`), trying the common adapter names. The result is cached for 5 seconds so we don't hit sysfs every frame.
   - The render loop now pauses when on battery, reusing the exact same pause/resume path already used for fullscreen detection.
   - Enabled by default (it's a power-saving feature for laptops) and can be turned off with `--no-pause-on-battery`, mirroring the existing `--no-fullscreen-pause` flag.

   ## Behavior / compatibility

   - Desktops without an AC adapter sysfs entry are treated as "on AC", so they keep rendering exactly as before.
   - No external dependencies added — it's a plain sysfs read.

   Happy to flip the default to opt-in (`--pause-on-battery`) instead if you'd prefer not to change default behavior for existing laptop users.