### PR TITLE
fix(scripting): correct inverted vector component validation in jsToDynamicValue

### DIFF
--- a/src/WallpaperEngine/Scripting/ScriptEngine.cpp
+++ b/src/WallpaperEngine/Scripting/ScriptEngine.cpp
@@ -153,7 +153,7 @@ static void jsToDynamicValue (JSContext* ctx, JSValue val, DynamicValue& source)
 	    JS_FreeValue (ctx, w);
 	});
 
-	if (!JS_IsNumber (x) || JS_IsNumber (y)) {
+	if (!JS_IsNumber (x) || !JS_IsNumber (y)) {
 	    sLog.exception ("Vector's x and y components must be numbers");
 	}
 


### PR DESCRIPTION
## Summary

`ScriptEngine::jsToDynamicValue` validates JS-supplied vector components
before converting them to `glm::vec2/3/4` from a scene script. The check
on the second component is missing the negation, so the guard fires
when `y` *is* a number — which is the common case.

## Why

In `src/WallpaperEngine/Scripting/ScriptEngine.cpp:156`:

```cpp
if (!JS_IsNumber (x) || JS_IsNumber (y)) {
    sLog.exception ("Vector's x and y components must be numbers");
}
```

`JS_IsNumber` returns `bool`. With the predicate as written, the
disjunction is `true` whenever `y` is a valid number — i.e. for every
vector literal a scene script might pass. `sLog.exception` is
`[[noreturn]]` (`src/WallpaperEngine/Logging/Log.h:58-71`) and throws
`std::runtime_error`, which terminates the conversion and leaves the
underlying `DynamicValue` untouched. So:

- `{x: 10, y: 20}` (a perfectly valid 2D coordinate) → exception
- `{x: 0.0, y: 0.0, z: 1.0}` → same, propagated through `update()`

The intent of the guard is "throw only if any component is non-numeric".
The asymmetry between the two clauses is the regression.

This was introduced in #599 ("cleanup and optimization of scripting
engine"), which moved the parsing/validation logic into
`ScriptEngine::jsToDynamicValue` from the previous
`UserSettingParser::parse`.

## Touchpoints

- `src/WallpaperEngine/Scripting/ScriptEngine.cpp:156` — restore the
  missing `!` so both `x` and `y` need to fail the numeric check to
  throw.

## Compatibility Note

- One-character change in a boolean predicate, no signature changes.
- `glm::vec2/3/4` conversion paths and `DynamicValue` storage are
  untouched.
- The three sibling predicates for `z` and `w` (lines 165, 170) already
  use the correct `!JS_IsNumber` form, so the fix aligns the `x/y` pair
  with the rest.

## Scope Boundary

- Does NOT touch the `z`/`w` branches. They are already correct.
- Does NOT introduce new tests. The existing Catch2 suite does not
  exercise `jsToDynamicValue` (the `JS_TAG_OBJECT` branch runs only
  when a scene script supplies a JS object with `x/y/z/w` properties,
  which has no harness). Adding a JS-side test would require standing
  up QuickJS in the test binary, which is out of scope for a typo fix.
- Does NOT change the error message. It already names "x and y", which
  remains accurate after the fix.

## Validation

- File builds clean with `-Wall -Werror`. No new warnings on the
  modified line.
- Full project link succeeds: `cmake --build . --target
  linux-wallpaperengine` reaches `100% Built target linux-wallpaperengine`.
- Manual trace: with `{x: 1.0, y: 2.0}` (a `JS_TAG_OBJECT`), the
  disjunction now evaluates to `false || false`, control falls through
  to `JS_ToFloat64`, and `value->update (glm::vec2 (xVal, yVal), ...)`
  runs as intended.
- Manual trace: with `{x: "left", y: 1.0}`, the disjunction evaluates
  to `true || false`, `sLog.exception` fires, and the call throws
  `std::runtime_error` exactly as the original guard intended for
  malformed input.

## Related

- #599: cleanup and optimization of scripting engine (introduced the
  regression)
- #617: a related DynamicValueParser draft that turned out to be
  unnecessary given the post-#599 state of `preparseSize` (closed).