### PR TITLE
fix(scripting): release OpaqueScriptableObjectAdapter when the JS object is finalized

### DIFF
--- a/src/WallpaperEngine/Scripting/Adapters/ScriptableObjectAdapter.cpp
+++ b/src/WallpaperEngine/Scripting/Adapters/ScriptableObjectAdapter.cpp
@@ -18,6 +18,8 @@ struct OpaqueScriptableObjectAdapter {
     WallpaperEngine::Scripting::ScriptableObject& object;
 };
 
+void scriptableobject_finalizer (JSRuntime* rt, JSValueConst val);
+
 JSValue scriptableobject_property_get (JSContext* ctx, JSValueConst obj_val, JSAtom atom, JSValueConst receiver) {
     JSClassID classId = 0;
 
@@ -70,6 +72,7 @@ ScriptableObjectAdapter::ScriptableObjectAdapter (ScriptEngine& engine, std::str
     this->registerType (
 	{
 	    .class_name = m_name.c_str (),
+	    .finalizer = scriptableobject_finalizer,
 	    .exotic = &m_exoticMethods,
 	}
     );
@@ -83,6 +86,18 @@ JSValue ScriptableObjectAdapter::instantiate (ScriptableObject& object) {
     );
 
     return result;
+}
+
+void scriptableobject_finalizer (JSRuntime* rt, JSValueConst val) {
+    JSClassID classId = 0;
+
+    const auto* container = static_cast<OpaqueScriptableObjectAdapter*> (JS_GetAnyOpaque (val, &classId));
+
+    if (container == nullptr || container->magic != SCRIPTABLE_OPAQUE_MAGIC) {
+	return;
+    }
+
+    delete container;
 }
 
 JSValue ScriptableObjectAdapter::instantiate (DynamicValue& value) {


### PR DESCRIPTION
## Summary

`ScriptableObjectAdapter::instantiate` allocates an
`OpaqueScriptableObjectAdapter` on the heap and stores it via
`JS_SetOpaque`, but the `JSClassDef` passed to `JS_NewClass` registers no
finalizer. QuickJS drops the JSValue when the object becomes unreachable
while the heap struct lives on for the rest of the runtime.

## Why

`ScriptEngine` enables `JS_DUMP_LEAKS` on the runtime
(`src/WallpaperEngine/Scripting/ScriptEngine.cpp:199`), so on shutdown
QuickJS prints the count of leaked JSValues. Every `ScriptableObject`
that the adapter exposes to scene scripts (the `ILayer` root object,
plus anything inheriting `ScriptableObject` like scene-specific
controls) contributes one leaked `OpaqueScriptableObjectAdapter` to that
report. Magnitude per object is small (the struct holds two references
plus a magic field, ~24 bytes), but it is real, observable, and
unnecessary: a sibling adapter already does the right thing.

Compare `src/WallpaperEngine/Scripting/Adapters/VectorAdapter.cpp:398`:

```cpp
template <int components> void vector_finalizer (JSRuntime* rt, JSValueConst val) {
    JSClassID classId = 0;
    const auto* container = static_cast<VectorOpaqueContainer<components>*> (JS_GetAnyOpaque (val, &classId));

    if (!container || container->magic != (int)(VEC_OPAQUE_MAGIC + components)) {
        return;
    }

    if (container->id != InvalidVectorInstanceId) {
        container->adapter.free (container->id);
    }

    delete container;
}
```

`ScriptableObjectAdapter` should follow the same shape.

The refactor in #599 ("cleanup and optimization of scripting engine")
introduced this code path and forgot to wire the finalizer. This was
caught while auditing #599 for related regressions.

## Touchpoints

- `src/WallpaperEngine/Scripting/Adapters/ScriptableObjectAdapter.cpp`:
  - Forward-declare `scriptableobject_finalizer` after the
    `OpaqueScriptableObjectAdapter` struct so the constructor can name
    it.
  - Add `.finalizer = scriptableobject_finalizer` to the `JSClassDef`
    passed to `registerType` in the adapter constructor.
  - Define `scriptableobject_finalizer` after `instantiate`. Same shape
    as `vector_finalizer`: fetch the opaque, validate the magic, delete
    the container.

## Compatibility Note

- Behavior change is strictly positive: previously leaked heap memory
  is now released when the corresponding JS object is finalized. The
  struct itself holds only references (no owning pointers), so freeing
  it does not cascade.
- The `magic` check is defensive; a wrong class ID or stale opaque is
  silently ignored rather than crashing, matching the
  `vector_finalizer` precedent.
- No public API changes; no header changes.
- The `JS_DUMP_LEAKS` report on shutdown will show fewer leaks for the
  `ILayer` (and any other `ScriptableObject`-derived) class.

## Scope Boundary

- Does NOT touch `ScriptableObjectAdapter::instantiate (DynamicValue&)`.
  That overload already throws `runtime_error` and never allocates an
  opaque, so there is nothing to leak there.
- Does NOT change the constructor's `registerType` call shape. The
  brace-init list is extended in place; no helper extraction, no
  refactor.
- Does NOT add a new test. The existing Catch2 suite does not exercise
  the adapter path, and standing one up would require running the
  QuickJS runtime under the test binary. Out of scope for a leak fix
  that mirrors an existing pattern verbatim.

## Validation

- File builds clean with `-Wall -Werror`. No new warnings on the
  modified lines.
- Full project link succeeds: `cmake --build . --target
  linux-wallpaperengine` reaches `100% Built target linux-wallpaperengine`.
- Manual trace: a script that creates and drops `ILayer` references
  triggers `scriptableobject_finalizer` on collection; `JS_GetAnyOpaque`
  returns the same pointer that `JS_SetOpaque` stored in `instantiate`;
  the magic check passes; `delete container` runs.

## Related

- #599: cleanup and optimization of scripting engine (introduced the
  adapter; forgot the finalizer)
- #618: a separate typo fix in `jsToDynamicValue` from the same audit
  pass.