### PR TITLE
feat: puppet warp skeletal animation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "linux-wallpaperengine development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+
+      runtimeLibs = with pkgs; [
+        # Core graphics
+        libGL
+        libGLU
+        glew
+        freeglut
+        glfw
+
+        # X11
+        libx11
+        libxrandr
+        libxinerama
+        libxcursor
+        libxi
+        libxcomposite
+        libxdamage
+        libxext
+        libxxf86vm
+        libxcb
+
+        # Wayland
+        wayland
+        libxkbcommon
+        egl-wayland
+
+        # Audio
+        SDL2
+        libpulseaudio
+
+        # Video / codecs
+        ffmpeg
+        mpv
+
+        # Compression
+        lz4
+        zlib
+
+        # Text rendering
+        freetype
+
+        # IPC
+        dbus
+
+        # CEF runtime dependencies
+        cups
+        at-spi2-core
+        nss
+        nspr
+        glib
+        pango
+        cairo
+        gtk3
+        libdrm
+        mesa
+        alsa-lib
+        expat
+        systemd # libudev
+        atk
+      ];
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [
+          cmake
+          pkg-config
+          gcc
+          gnumake
+          wayland-scanner
+        ];
+
+        buildInputs = runtimeLibs ++ (with pkgs; [
+          glm
+          wayland-protocols
+          fftw
+        ]);
+
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibs;
+
+        shellHook = ''
+          echo "linux-wallpaperengine dev shell"
+          echo "Build with:"
+          echo "  cmake -B build -DCMAKE_BUILD_TYPE=Release -Wno-dev -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined -DCMAKE_SHARED_LINKER_FLAGS=-Wl,--allow-shlib-undefined"
+          echo "  cmake --build build -j$(nproc)"
+        '';
+      };
+    };
+}

--- a/src/WallpaperEngine/Data/Model/Model.h
+++ b/src/WallpaperEngine/Data/Model/Model.h
@@ -3,6 +3,8 @@
 #include <optional>
 #include <string>
 
+#include <glm/vec2.hpp>
+
 #include "Types.h"
 
 namespace WallpaperEngine::Data::Model {
@@ -28,5 +30,7 @@ struct ModelStruct {
     std::optional<int> height;
     /** Model file for puppet */
     std::optional<std::string> puppet;
+    /** Offset applied to puppet mesh to align it within the image */
+    glm::vec2 cropoffset = glm::vec2 (0.0f);
 };
 } // namespace WallpaperEngine::Data::Model

--- a/src/WallpaperEngine/Data/Model/Object.h
+++ b/src/WallpaperEngine/Data/Model/Object.h
@@ -610,8 +610,8 @@ struct TextData {
     std::string alignment;
     /** Vertical alignment: "top", "center", "bottom" */
     std::string verticalalign;
-    /** Padding inside the bounding box */
-    int padding;
+    /** Padding inside the bounding box (x = horizontal, y = vertical) */
+    glm::vec2 padding;
     // TODO: PARSE LIMITS TOO!
 };
 

--- a/src/WallpaperEngine/Data/Parsers/ModelParser.cpp
+++ b/src/WallpaperEngine/Data/Parsers/ModelParser.cpp
@@ -30,5 +30,6 @@ ModelUniquePtr ModelParser::parse (const JSON& file, const Project& project, con
 	.width = file.optional<int> ("width"),
 	.height = file.optional<int> ("height"),
 	.puppet = file.optional<std::string> ("puppet"),
+	.cropoffset = file.optional ("cropoffset", glm::vec2 (0.0f)),
     });
 }

--- a/src/WallpaperEngine/Data/Parsers/ObjectParser.cpp
+++ b/src/WallpaperEngine/Data/Parsers/ObjectParser.cpp
@@ -17,6 +17,38 @@
 using namespace WallpaperEngine::Data::Parsers;
 using namespace WallpaperEngine::Data::Model;
 
+namespace {
+glm::vec2 parsePadding (const JSON& it) {
+    using WallpaperEngine::Data::Builders::VectorBuilder;
+    const auto opt = it.optional ("padding");
+
+    if (!opt.has_value ()) {
+        return glm::vec2 (0.0f);
+    }
+
+    const auto& val = *opt;
+
+    if (val.is_number ()) {
+        const auto v = val.get<float> ();
+        return glm::vec2 (v, v);
+    }
+
+    if (val.is_string ()) {
+        const auto str = val.get<std::string> ();
+        const auto size = VectorBuilder::preparseSize (str);
+
+        if (size == 1) {
+            const auto v = std::strtof (str.c_str (), nullptr);
+            return glm::vec2 (v, v);
+        }
+
+        return VectorBuilder::parse<glm::vec2> (str);
+    }
+
+    return glm::vec2 (0.0f);
+}
+} // namespace
+
 ObjectUniquePtr ObjectParser::parse (const JSON& it, const Project& project) {
     const auto imageIt = it.find ("image");
     const auto soundIt = it.find ("sound");
@@ -136,7 +168,7 @@ TextUniquePtr ObjectParser::parseText (const JSON& it, const Project& project, O
 	    .visible = it.user ("visible", project.properties, true),
 	    .alignment = it.optional ("horizontalalign", it.optional ("alignment", std::string ("center"))),
 	    .verticalalign = it.optional ("verticalalign", std::string ("center")),
-	    .padding = it.optional ("padding", 0),
+	    .padding = parsePadding (it),
 	}
     );
 }

--- a/src/WallpaperEngine/Data/Parsers/PropertyParser.cpp
+++ b/src/WallpaperEngine/Data/Parsers/PropertyParser.cpp
@@ -147,6 +147,6 @@ PropertySharedPtr PropertyParser::parseTextInput (const JSON& it, const std::str
 	    .name = name,
 	    .text = it.optional<std::string> ("text", ""),
 	},
-	it.require ("value", "Property must have a value").dump ()
+	it.optional<std::string> ("value", "")
     );
 }

--- a/src/WallpaperEngine/Data/Parsers/WallpaperParser.cpp
+++ b/src/WallpaperEngine/Data/Parsers/WallpaperParser.cpp
@@ -25,8 +25,8 @@ SceneUniquePtr WallpaperParser::parseScene (const JSON& file, Project& project) 
     const auto scene = JSON::parse (project.assetLocator->readString (file));
     const auto camera = scene.require ("camera", "Scenes must have a camera section");
     const auto general = scene.require ("general", "Scenes must have a general section");
-    const auto projection
-	= general.require ("orthogonalprojection", "General section must have orthogonal projection info");
+    const auto projectionOpt = general.optional ("orthogonalprojection");
+    const bool projectionIsAuto = !projectionOpt.has_value () || projectionOpt->optional ("auto", false);
     const auto objects = scene.require ("objects", "Scenes must have an objects section");
     const auto& properties = project.properties;
 
@@ -69,9 +69,9 @@ SceneUniquePtr WallpaperParser::parseScene (const JSON& file, Project& project) 
                     .up = camera.require <glm::vec3> ("up", "Camera must have an up position"),
                 },
                 .projection = {
-                    .width  = projection.optional ("auto", false) ? 0 : projection.require <int> ("width",  "Projection must have a width"),
-                    .height = projection.optional ("auto", false) ? 0 : projection.require <int> ("height", "Projection must have a height"),
-                    .isAuto = projection.optional ("auto", false),
+                    .width  = projectionIsAuto ? 0 : projectionOpt->require <int> ("width",  "Projection must have a width"),
+                    .height = projectionIsAuto ? 0 : projectionOpt->require <int> ("height", "Projection must have a height"),
+                    .isAuto = projectionIsAuto,
                     .nearz = camera.user ("nearz", properties, 0.0f),
                     .farz = camera.user ("farz", properties, 1000.0f),
                     .fov = camera.user ("fov", properties, 50.0f)

--- a/src/WallpaperEngine/Render/CObject.cpp
+++ b/src/WallpaperEngine/Render/CObject.cpp
@@ -2,12 +2,83 @@
 
 #include <utility>
 
+#include "WallpaperEngine/Data/Model/Object.h"
+#include "WallpaperEngine/Logging/Log.h"
+
 using namespace WallpaperEngine;
 using namespace WallpaperEngine::Render;
 using namespace WallpaperEngine::Render::Wallpapers;
 
+namespace {
+// angles are already in radians in scene.json — see CParticle.cpp
+glm::vec2 rotateVec2 (const glm::vec2& value, const float angle) {
+    const float cosAngle = std::cos (angle);
+    const float sinAngle = std::sin (angle);
+    return { value.x * cosAngle - value.y * sinAngle, value.x * sinAngle + value.y * cosAngle };
+}
+} // namespace
+
 CObject::CObject (Wallpapers::CScene& scene, const Object& object) :
     Helpers::ContextAware (scene), m_scene (scene), m_object (object) { }
+
+CObject::ResolvedTransform CObject::localTransform (const Object& object) {
+    glm::vec3 origin = object.origin->value->getVec3 ();
+    glm::vec3 scale = glm::vec3 (1.0f);
+    float angle = 0.0f;
+
+    if (object.is<Image> ()) {
+	const auto* image = object.as<Image> ();
+	scale = image->scale->value->getVec3 ();
+	angle = image->angles->value->getVec3 ().z;
+    } else if (object.is<Text> ()) {
+	const auto* text = object.as<Text> ();
+	scale = text->scale->value->getVec3 ();
+    } else {
+	scale = object.groupScale->value->getVec3 ();
+	angle = object.groupAngles->value->getVec3 ().z;
+    }
+
+    return { origin, scale, angle };
+}
+
+CObject::ResolvedTransform CObject::resolveTransform (const Object& object) const {
+    constexpr int kMaxParentDepth = 32;
+
+    // Walk up the parent chain leaf-first, bounded by kMaxParentDepth to guard
+    // against cycles. chain[0] is the requested object; the last entry is the root.
+    const Object* chain[kMaxParentDepth + 1];
+    int count = 0;
+    const Object* current = &object;
+    chain[count++] = current;
+
+    while (current->parent.has_value ()) {
+	if (count > kMaxParentDepth) {
+	    sLog.error ("Parent transform chain is too deep; possible cycle at object id=", current->id);
+	    break;
+	}
+	const auto* parentObject = this->getScene ().getObject (current->parent.value ());
+	if (parentObject == nullptr) {
+	    break;
+	}
+	current = &parentObject->getObject ();
+	chain[count++] = current;
+    }
+
+    // Accumulate top-down: the root's local transform is already its resolved
+    // transform, then fold each child onto its already-resolved parent.
+    ResolvedTransform resolved = localTransform (*chain[count - 1]);
+    for (int i = count - 2; i >= 0; --i) {
+	ResolvedTransform local = localTransform (*chain[i]);
+	const glm::vec2 offset
+	    = rotateVec2 ({ local.origin.x * resolved.scale.x, local.origin.y * resolved.scale.y }, resolved.angle);
+	local.origin.x = resolved.origin.x + offset.x;
+	local.origin.y = resolved.origin.y + offset.y;
+	local.origin.z = resolved.origin.z + local.origin.z * resolved.scale.z;
+	resolved = { local.origin, local.scale * resolved.scale, local.angle + resolved.angle };
+    }
+
+    return resolved;
+}
 
 void CObject::setup () { }
 void CObject::render () { }

--- a/src/WallpaperEngine/Render/CObject.h
+++ b/src/WallpaperEngine/Render/CObject.h
@@ -24,6 +24,23 @@ public:
     [[nodiscard]] int getId () const;
     [[nodiscard]] const Object& getObject () const;
 
+    struct ResolvedTransform {
+	glm::vec3 origin;
+	glm::vec3 scale;
+	float angle;
+    };
+
+    /**
+     * Resolves the object's transform (origin/scale/angle) by walking the parent chain.
+     */
+    [[nodiscard]] ResolvedTransform resolveTransform (const Object& object) const;
+
+    /**
+     * Computes the object's own transform (origin/scale/angle) without walking the
+     * parent chain. Used as the per-node step of resolveTransform.
+     */
+    [[nodiscard]] static ResolvedTransform localTransform (const Object& object);
+
 private:
     Wallpapers::CScene& m_scene;
     const Object& m_object;

--- a/src/WallpaperEngine/Render/Objects/CImage.cpp
+++ b/src/WallpaperEngine/Render/Objects/CImage.cpp
@@ -3,6 +3,7 @@
 #include "CRenderable.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <iterator>
 #include <optional>
@@ -10,6 +11,7 @@
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/rotate_vector.hpp>
 #undef GLM_ENABLE_EXPERIMENTAL
@@ -31,12 +33,6 @@ using namespace WallpaperEngine::Data::Builders;
 using namespace WallpaperEngine::Data::Utils;
 
 namespace {
-glm::vec2 rotateVec2 (const glm::vec2& value, float angle) {
-    const float cosAngle = std::cos (angle);
-    const float sinAngle = std::sin (angle);
-    return { value.x * cosAngle - value.y * sinAngle, value.x * sinAngle + value.y * cosAngle };
-}
-
 bool isMagentaNeonTint (const glm::vec3& color) { return color.r > 0.55f && color.g < 0.25f && color.b > 0.45f; }
 
 std::optional<glm::vec3> findMagentaCompositeTint (const Image& image, const std::vector<int>& skippedEffectIds) {
@@ -108,65 +104,6 @@ std::optional<PuppetMeshBlock> findPuppetMeshBlock (
 }
 }
 
-CImage::ResolvedTransform CImage::localTransform (const Object& object) {
-    glm::vec3 origin = object.origin->value->getVec3 ();
-    glm::vec3 scale = glm::vec3 (1.0f);
-    float angle = 0.0f;
-
-    if (object.is<Image> ()) {
-	const auto* image = object.as<Image> ();
-	scale = image->scale->value->getVec3 ();
-	angle = image->angles->value->getVec3 ().z;
-    } else if (object.is<Text> ()) {
-	const auto* text = object.as<Text> ();
-	scale = text->scale->value->getVec3 ();
-    } else {
-	scale = object.groupScale->value->getVec3 ();
-	angle = object.groupAngles->value->getVec3 ().z;
-    }
-
-    return { origin, scale, angle };
-}
-
-CImage::ResolvedTransform CImage::resolveTransform (const Object& object) const {
-    constexpr int kMaxParentDepth = 32;
-
-    // Walk up the parent chain leaf-first, bounded by kMaxParentDepth to guard
-    // against cycles. chain[0] is the requested object; the last entry is the root.
-    const Object* chain[kMaxParentDepth + 1];
-    int count = 0;
-    const Object* current = &object;
-    chain[count++] = current;
-
-    while (current->parent.has_value ()) {
-	if (count > kMaxParentDepth) {
-	    sLog.error ("Parent transform chain is too deep; possible cycle at object id=", current->id);
-	    break;
-	}
-	const auto* parentObject = this->getScene ().getObject (current->parent.value ());
-	if (parentObject == nullptr) {
-	    break;
-	}
-	current = &parentObject->getObject ();
-	chain[count++] = current;
-    }
-
-    // Accumulate top-down: the root's local transform is already its resolved
-    // transform, then fold each child onto its already-resolved parent.
-    ResolvedTransform resolved = localTransform (*chain[count - 1]);
-    for (int i = count - 2; i >= 0; --i) {
-	ResolvedTransform local = localTransform (*chain[i]);
-	const glm::vec2 offset
-	    = rotateVec2 ({ local.origin.x * resolved.scale.x, local.origin.y * resolved.scale.y }, resolved.angle);
-	local.origin.x = resolved.origin.x + offset.x;
-	local.origin.y = resolved.origin.y + offset.y;
-	local.origin.z = resolved.origin.z + local.origin.z * resolved.scale.z;
-	resolved = { local.origin, local.scale * resolved.scale, local.angle + resolved.angle };
-    }
-
-    return resolved;
-}
-
 CImage::CImage (Wallpapers::CScene& scene, const Image& image) :
     CObject (scene, image), CRenderable (scene, image, *image.model->material), ScriptableObject (scene, image),
     m_sceneSpacePosition (GL_NONE), m_copySpacePosition (GL_NONE), m_passSpacePosition (GL_NONE),
@@ -228,6 +165,12 @@ CImage::CImage (Wallpapers::CScene& scene, const Image& image) :
 	origin = { scene_width / 2, scene_height / 2, 0 };
 
 	// TODO: CHANGE ALIGNMENT TOO?
+    }
+    // load the puppet mesh early: the canvas may need to grow to fit the animated mesh,
+    // which affects the quad, the FBO sizes and the local projections below
+    this->m_hasPuppetMesh = this->loadPuppetMesh (size);
+    if (this->m_hasPuppetMesh) {
+	size = this->m_puppetSize;
     }
     this->m_size = size;
 
@@ -372,8 +315,6 @@ CImage::CImage (Wallpapers::CScene& scene, const Image& image) :
     glBindBuffer (GL_ARRAY_BUFFER, this->m_texcoordPass);
     glBufferData (GL_ARRAY_BUFFER, sizeof (texcoordPass), texcoordPass, GL_STATIC_DRAW);
 
-    this->m_hasPuppetMesh = this->loadPuppetMesh (size);
-
     // compute the center of the image in scene space for rotation
     this->m_sceneCenter
 	= glm::vec3 ((this->m_pos.x + this->m_pos.z) / 2.0f, (this->m_pos.y + this->m_pos.w) / 2.0f, 0.0f);
@@ -433,13 +374,27 @@ bool CImage::loadPuppetMesh (const glm::vec2& size) {
 
 	constexpr size_t markerSize = 9;
 	constexpr size_t meshHeaderSize = sizeof (uint32_t) * 2;
-	constexpr size_t vertexStride = 80;
 	constexpr size_t positionOffset = 0;
-	constexpr size_t uvOffset = 72;
 
 	const std::string puppetVersion
 	    = data.size () >= markerSize ? std::string (data.data (), strlen ("MDLV0021")) : "";
-	if (puppetVersion != "MDLV0021" && puppetVersion != "MDLV0023") {
+
+	size_t vertexStride;
+	size_t uvOffset;
+	size_t boneIndexOffset;
+	size_t boneWeightOffset;
+
+	if (puppetVersion == "MDLV0013") {
+	    vertexStride = 52;
+	    uvOffset = 44;
+	    boneIndexOffset = 12;
+	    boneWeightOffset = 28;
+	} else if (puppetVersion == "MDLV0021" || puppetVersion == "MDLV0023") {
+	    vertexStride = 80;
+	    uvOffset = 72;
+	    boneIndexOffset = 40;
+	    boneWeightOffset = 56;
+	} else {
 	    sLog.error ("Unsupported puppet model header ", puppetVersion, " in ", *this->getImage ().model->puppet);
 	    return false;
 	}
@@ -471,6 +426,10 @@ bool CImage::loadPuppetMesh (const glm::vec2& size) {
 
 	this->m_puppetRawPositions.clear ();
 	this->m_puppetRawPositions.reserve (vertexCount * 3);
+	this->m_puppetVertexBones.clear ();
+	this->m_puppetVertexBones.reserve (vertexCount);
+	this->m_puppetVertexWeights.clear ();
+	this->m_puppetVertexWeights.reserve (vertexCount);
 	texcoords.reserve (vertexCount * 2);
 	indices.reserve (indexCount);
 
@@ -480,6 +439,16 @@ bool CImage::loadPuppetMesh (const glm::vec2& size) {
 	    const float x = reader.nextFloat ();
 	    const float y = reader.nextFloat ();
 	    const float z = reader.nextFloat ();
+	    reader.base ().seekg (static_cast<std::streamoff> (vertexOffset + boneIndexOffset), std::ios::beg);
+	    glm::uvec4 bones;
+	    for (int component = 0; component < 4; component++) {
+		bones[component] = reader.nextUInt32 ();
+	    }
+	    reader.base ().seekg (static_cast<std::streamoff> (vertexOffset + boneWeightOffset), std::ios::beg);
+	    glm::vec4 weights;
+	    for (int component = 0; component < 4; component++) {
+		weights[component] = reader.nextFloat ();
+	    }
 	    reader.base ().seekg (static_cast<std::streamoff> (vertexOffset + uvOffset), std::ios::beg);
 	    const float u = reader.nextFloat ();
 	    const float v = reader.nextFloat ();
@@ -487,6 +456,8 @@ bool CImage::loadPuppetMesh (const glm::vec2& size) {
 	    this->m_puppetRawPositions.push_back (x);
 	    this->m_puppetRawPositions.push_back (y);
 	    this->m_puppetRawPositions.push_back (z);
+	    this->m_puppetVertexBones.push_back (bones);
+	    this->m_puppetVertexWeights.push_back (weights);
 	    texcoords.push_back (u);
 	    texcoords.push_back (v);
 	}
@@ -502,7 +473,15 @@ bool CImage::loadPuppetMesh (const glm::vec2& size) {
 	    indices.push_back (value);
 	}
 
-	this->updatePuppetPositionBuffer (size);
+	if (!this->loadPuppetAnimationData (data, mdlsOffset)) {
+	    // no animation data means the mesh can only be rendered in its bind pose
+	    this->m_puppetBones.clear ();
+	    this->m_puppetAnimations.clear ();
+	}
+
+	// autosize: the canvas may need to grow so the animated mesh never clips
+	this->m_puppetSize = this->computePuppetCanvasSize (size);
+	this->updatePuppetPositionBuffer (this->m_puppetSize, this->m_puppetRawPositions);
 
 	glGenBuffers (1, &this->m_puppetTexCoord);
 	glBindBuffer (GL_ARRAY_BUFFER, this->m_puppetTexCoord);
@@ -525,17 +504,348 @@ bool CImage::loadPuppetMesh (const glm::vec2& size) {
     }
 }
 
-void CImage::updatePuppetPositionBuffer (const glm::vec2& size) {
-    if (this->m_puppetRawPositions.empty ()) {
+bool CImage::loadPuppetAnimationData (const std::vector<char>& data, const size_t mdlsOffset) {
+    constexpr size_t markerSize = 9;
+
+    this->m_puppetBones.clear ();
+    this->m_puppetAnimations.clear ();
+
+    if (mdlsOffset + markerSize > data.size ()) {
+	return false;
+    }
+
+    const std::string skeletonVersion (data.data () + mdlsOffset, strlen ("MDLS0001"));
+    if (skeletonVersion != "MDLS0001" && skeletonVersion != "MDLS0003") {
+	sLog.error ("Unsupported puppet skeleton header ", skeletonVersion, " in ", *this->getImage ().model->puppet);
+	return false;
+    }
+
+    size_t cursor = mdlsOffset + markerSize;
+    const auto ensure = [&data, &cursor] (const size_t bytes) {
+	if (cursor + bytes > data.size ()) {
+	    throw std::runtime_error ("puppet skeleton data out of bounds");
+	}
+    };
+    const auto readUInt32 = [&data, &cursor, &ensure] () {
+	ensure (sizeof (uint32_t));
+	uint32_t value;
+	std::memcpy (&value, data.data () + cursor, sizeof (value));
+	cursor += sizeof (value);
+	return value;
+    };
+    const auto readFloat = [&data, &cursor, &ensure] () {
+	ensure (sizeof (float));
+	float value;
+	std::memcpy (&value, data.data () + cursor, sizeof (value));
+	cursor += sizeof (value);
+	return value;
+    };
+    const auto readString = [&data, &cursor, &ensure] () {
+	std::string value;
+	while (true) {
+	    ensure (1);
+	    const char character = data[cursor++];
+	    if (character == 0) {
+		return value;
+	    }
+	    value += character;
+	}
+    };
+
+    try {
+	readUInt32 (); // offset of the next section
+	const uint32_t boneCount = readUInt32 ();
+	if (boneCount == 0 || boneCount > 256) {
+	    return false;
+	}
+
+	std::vector<glm::mat4> bindWorld (boneCount);
+	for (uint32_t index = 0; index < boneCount; index++) {
+	    readString (); // bone name, usually empty
+	    readUInt32 (); // flags
+	    const auto parent = static_cast<int32_t> (readUInt32 ());
+	    const uint32_t matrixSize = readUInt32 ();
+	    if (matrixSize != sizeof (float) * 16 || parent < -1 || parent >= static_cast<int32_t> (index)) {
+		return false;
+	    }
+
+	    glm::mat4 local;
+	    ensure (matrixSize);
+	    std::memcpy (glm::value_ptr (local), data.data () + cursor, matrixSize);
+	    cursor += matrixSize;
+	    cursor += 1; // null separator
+
+	    bindWorld[index] = parent >= 0 ? bindWorld[parent] * local : local;
+	    this->m_puppetBones.push_back ({ .parent = parent, .inverseBindWorld = glm::inverse (bindWorld[index]) });
+	}
+
+	// animation data follows the skeleton in its own section
+	const size_t mdlaOffset = [&data, cursor] () -> size_t {
+	    for (size_t offset = cursor; offset + strlen ("MDLA") < data.size (); offset++) {
+		if (std::memcmp (data.data () + offset, "MDLA", strlen ("MDLA")) == 0) {
+		    return offset;
+		}
+	    }
+	    return data.size ();
+	}();
+	if (mdlaOffset + markerSize > data.size ()) {
+	    return false;
+	}
+
+	cursor = mdlaOffset + markerSize;
+	readUInt32 (); // offset of the next section
+	const uint32_t animationCount = readUInt32 ();
+	if (animationCount > 64) {
+	    return false;
+	}
+
+	for (uint32_t index = 0; index < animationCount; index++) {
+	    PuppetAnimation animation;
+	    animation.id = readUInt32 ();
+	    readUInt32 (); // unknown
+	    animation.name = readString ();
+	    animation.loop = readString () == "loop";
+	    animation.fps = readFloat ();
+	    if (animation.fps <= 0.0f) {
+		animation.fps = 30.0f;
+	    }
+	    readUInt32 (); // last frame number
+	    readUInt32 (); // unknown
+	    const uint32_t trackCount = readUInt32 ();
+	    if (trackCount != boneCount) {
+		return false;
+	    }
+
+	    animation.tracks.reserve (trackCount);
+	    for (uint32_t track = 0; track < trackCount; track++) {
+		readUInt32 (); // unknown
+		const uint32_t trackBytes = readUInt32 ();
+		constexpr uint32_t frameSize = sizeof (float) * 9;
+		if (trackBytes % frameSize != 0) {
+		    return false;
+		}
+
+		std::vector<PuppetAnimationFrame> frames (trackBytes / frameSize);
+		for (auto& frame : frames) {
+		    for (int component = 0; component < 3; component++) {
+			frame.position[component] = readFloat ();
+		    }
+		    for (int component = 0; component < 3; component++) {
+			frame.rotation[component] = readFloat ();
+		    }
+		    for (int component = 0; component < 3; component++) {
+			frame.scale[component] = readFloat ();
+		    }
+		}
+
+		animation.tracks.push_back (std::move (frames));
+	    }
+
+	    // all tracks must carry the same number of samples for interpolation
+	    bool consistent = true;
+	    for (const auto& track : animation.tracks) {
+		if (track.size () != animation.tracks.front ().size ()) {
+		    consistent = false;
+		    break;
+		}
+	    }
+	    if (consistent && !animation.tracks.empty () && !animation.tracks.front ().empty ()) {
+		this->m_puppetAnimations.push_back (std::move (animation));
+	    }
+
+	    // each animation is followed by a zero footer (4 bytes in MDLA0001, 35 in
+	    // MDLA0006) — skip it so the next animation's id is read from the right spot
+	    while (cursor < data.size () && data[cursor] == 0) {
+		cursor++;
+	    }
+	}
+    } catch (const std::exception& ex) {
+	sLog.error ("Could not load puppet animation ", *this->getImage ().model->puppet, ": ", ex.what ());
+	return false;
+    }
+
+    return !this->m_puppetAnimations.empty ();
+}
+
+void CImage::updatePuppetAnimation () {
+    if (this->m_puppetAnimations.empty () || this->m_puppetBones.empty () || this->m_puppetVertexBones.empty ()) {
+	return;
+    }
+
+    // pick the animation from the first visible animation layer, defaulting to the first animation available
+    const PuppetAnimation* animation = &this->m_puppetAnimations.front ();
+    float rate = 1.0f;
+    for (const auto& layer : this->getImage ().animationLayers) {
+	if (!layer->visible->value->getBool ()) {
+	    continue;
+	}
+
+	const auto animationId = static_cast<uint32_t> (layer->animation->value->getInt ());
+	const auto match = std::find_if (
+	    this->m_puppetAnimations.begin (), this->m_puppetAnimations.end (),
+	    [animationId] (const PuppetAnimation& cur) { return cur.id == animationId; }
+	);
+	if (match == this->m_puppetAnimations.end ()) {
+	    continue;
+	}
+
+	animation = &*match;
+	rate = layer->rate->value->getFloat ();
+	break;
+    }
+
+    const size_t boneCount = this->m_puppetBones.size ();
+    if (animation->tracks.size () != boneCount || animation->tracks.front ().empty ()) {
+	return;
+    }
+
+    const size_t sampleCount = animation->tracks.front ().size ();
+    const auto span = static_cast<float> (sampleCount - 1);
+    float framePosition = this->getScene ().getTime () * animation->fps * rate;
+    if (span <= 0.0f) {
+	framePosition = 0.0f;
+    } else if (animation->loop) {
+	framePosition = std::fmod (framePosition, span);
+	if (framePosition < 0.0f) {
+	    framePosition += span;
+	}
+    } else {
+	framePosition = std::clamp (framePosition, 0.0f, span);
+    }
+
+    std::vector<glm::mat4> skin (boneCount);
+    this->evaluatePuppetSkin (*animation, framePosition, skin);
+
+    this->m_puppetSkinnedPositions.resize (this->m_puppetRawPositions.size ());
+    const size_t vertexCount = this->m_puppetRawPositions.size () / 3;
+    for (size_t index = 0; index < vertexCount; index++) {
+	const glm::vec4 base (
+	    this->m_puppetRawPositions[index * 3], this->m_puppetRawPositions[index * 3 + 1],
+	    this->m_puppetRawPositions[index * 3 + 2], 1.0f
+	);
+	glm::vec3 result (0.0f);
+	float totalWeight = 0.0f;
+	for (int component = 0; component < 4; component++) {
+	    const float weight = this->m_puppetVertexWeights[index][component];
+	    const uint32_t bone = this->m_puppetVertexBones[index][component];
+	    if (weight <= 0.0f || bone >= boneCount) {
+		continue;
+	    }
+
+	    result += weight * glm::vec3 (skin[bone] * base);
+	    totalWeight += weight;
+	}
+
+	if (totalWeight <= 0.0f) {
+	    result = glm::vec3 (base);
+	} else {
+	    result /= totalWeight;
+	}
+
+	this->m_puppetSkinnedPositions[index * 3] = result.x;
+	this->m_puppetSkinnedPositions[index * 3 + 1] = result.y;
+	// flatten depth: 3D bone rotations otherwise push vertices out of the
+	// FBO ortho projection's [-1, 1] clip range, cutting the mesh
+	this->m_puppetSkinnedPositions[index * 3 + 2] = 0.0f;
+    }
+
+    this->updatePuppetPositionBuffer (this->m_puppetSize, this->m_puppetSkinnedPositions);
+}
+
+void CImage::evaluatePuppetSkin (
+    const PuppetAnimation& animation, const float framePosition, std::vector<glm::mat4>& skin
+) const {
+    const size_t boneCount = this->m_puppetBones.size ();
+    const size_t sampleCount = animation.tracks.front ().size ();
+    const auto frame = std::min (static_cast<size_t> (framePosition), sampleCount - 1);
+    const size_t nextFrame = std::min (frame + 1, sampleCount - 1);
+    const float blend = framePosition - static_cast<float> (frame);
+
+    std::vector<glm::mat4> world (boneCount);
+    for (size_t index = 0; index < boneCount; index++) {
+	const auto& from = animation.tracks[index][frame];
+	const auto& to = animation.tracks[index][nextFrame];
+	const glm::vec3 position = glm::mix (from.position, to.position, blend);
+	const glm::vec3 rotation = glm::mix (from.rotation, to.rotation, blend);
+	const glm::vec3 scale = glm::mix (from.scale, to.scale, blend);
+
+	// rotations are authored in WE's y-down space while the mesh lives in y-up
+	// coordinates: conjugating by the y-flip negates the x and z rotations
+	glm::mat4 local = glm::translate (glm::mat4 (1.0f), position);
+	local = glm::rotate (local, -rotation.z, glm::vec3 (0.0f, 0.0f, 1.0f));
+	local = glm::rotate (local, rotation.y, glm::vec3 (0.0f, 1.0f, 0.0f));
+	local = glm::rotate (local, -rotation.x, glm::vec3 (1.0f, 0.0f, 0.0f));
+	local = glm::scale (local, scale);
+
+	const int parent = this->m_puppetBones[index].parent;
+	world[index] = parent >= 0 ? world[parent] * local : local;
+	skin[index] = world[index] * this->m_puppetBones[index].inverseBindWorld;
+    }
+}
+
+glm::vec2 CImage::computePuppetCanvasSize (const glm::vec2& size) const {
+    // autosize: measure the mesh across every animation frame and grow the canvas
+    // symmetrically so the animated puppet never clips at the FBO edges
+    float maxAbsX = size.x / 2.0f;
+    float maxAbsY = size.y / 2.0f;
+
+    const size_t vertexCount = this->m_puppetRawPositions.size () / 3;
+    const size_t boneCount = this->m_puppetBones.size ();
+
+    std::vector<glm::mat4> skin (boneCount);
+    for (const auto& animation : this->m_puppetAnimations) {
+	if (animation.tracks.size () != boneCount) {
+	    continue;
+	}
+
+	const size_t sampleCount = animation.tracks.front ().size ();
+	for (size_t frame = 0; frame < sampleCount; frame++) {
+	    this->evaluatePuppetSkin (animation, static_cast<float> (frame), skin);
+
+	    for (size_t index = 0; index < vertexCount; index++) {
+		const glm::vec4 base (
+		    this->m_puppetRawPositions[index * 3], this->m_puppetRawPositions[index * 3 + 1],
+		    this->m_puppetRawPositions[index * 3 + 2], 1.0f
+		);
+		glm::vec3 result (0.0f);
+		float totalWeight = 0.0f;
+		for (int component = 0; component < 4; component++) {
+		    const float weight = this->m_puppetVertexWeights[index][component];
+		    const uint32_t bone = this->m_puppetVertexBones[index][component];
+		    if (weight <= 0.0f || bone >= boneCount) {
+			continue;
+		    }
+
+		    result += weight * glm::vec3 (skin[bone] * base);
+		    totalWeight += weight;
+		}
+
+		if (totalWeight <= 0.0f) {
+		    result = glm::vec3 (base);
+		} else {
+		    result /= totalWeight;
+		}
+
+		maxAbsX = std::max (maxAbsX, std::abs (result.x));
+		maxAbsY = std::max (maxAbsY, std::abs (result.y));
+	    }
+	}
+    }
+
+    return { std::ceil (maxAbsX) * 2.0f, std::ceil (maxAbsY) * 2.0f };
+}
+
+void CImage::updatePuppetPositionBuffer (const glm::vec2& size, const std::vector<GLfloat>& rawPositions) {
+    if (rawPositions.empty ()) {
 	return;
     }
 
     std::vector<GLfloat> positions;
-    positions.reserve (this->m_puppetRawPositions.size ());
-    for (size_t index = 0; index + 2 < this->m_puppetRawPositions.size (); index += 3) {
-	positions.push_back (size.x / 2.0f + this->m_puppetRawPositions[index]);
-	positions.push_back (size.y / 2.0f - this->m_puppetRawPositions[index + 1]);
-	positions.push_back (this->m_puppetRawPositions[index + 2]);
+    positions.reserve (rawPositions.size ());
+    for (size_t index = 0; index + 2 < rawPositions.size (); index += 3) {
+	positions.push_back (size.x / 2.0f + rawPositions[index]);
+	positions.push_back (size.y / 2.0f - rawPositions[index + 1]);
+	positions.push_back (rawPositions[index + 2]);
     }
 
     if (this->m_puppetSpacePosition == GL_NONE) {
@@ -921,6 +1231,10 @@ void CImage::render () {
     // Always update screen transform (handles rotation + parallax dynamically)
     this->updateScreenSpacePosition ();
 
+    if (this->m_hasPuppetMesh) {
+	this->updatePuppetAnimation ();
+    }
+
 #if !NDEBUG
     std::string str = "Image ";
 
@@ -962,6 +1276,11 @@ const glm::vec4& CImage::getColor4 () const { return this->m_image.color->value-
 const glm::vec3& CImage::getCompositeColor () const { return this->m_image.color->value->getVec3 (); }
 
 glm::vec2 CImage::resolveGeometrySize (float sceneWidth, float sceneHeight, glm::vec3& origin) const {
+    // puppet canvases are expanded to fit the animated mesh (see loadPuppetMesh)
+    if (this->m_hasPuppetMesh && this->m_puppetSize.x > 0.0f && this->m_puppetSize.y > 0.0f) {
+	return this->m_puppetSize;
+    }
+
     glm::vec2 size = this->getSize ();
 
     if ((size.x == 0.0f || size.y == 0.0f) && this->m_texture != nullptr) {
@@ -984,8 +1303,13 @@ glm::vec2 CImage::resolveGeometrySize (float sceneWidth, float sceneHeight, glm:
 }
 
 void CImage::updateScenePosition (
-    const glm::vec3& origin, const glm::vec2& size, const glm::vec3& scale, float sceneWidth, float sceneHeight
+    const glm::vec3& origin_in, const glm::vec2& size, const glm::vec3& scale, float sceneWidth, float sceneHeight
 ) {
+    glm::vec3 origin = origin_in;
+
+    // note: model cropoffset is deliberately NOT applied anywhere — it's editor metadata;
+    // object origins already refer to the cropped canvas center (verified against WE)
+
     const glm::vec2 scaledSize = size * glm::vec2 (scale);
     this->m_pos.x = origin.x - (scaledSize.x / 2.0f);
     this->m_pos.w = origin.y + (scaledSize.y / 2.0f);
@@ -1083,7 +1407,8 @@ CImage::ResolvedTransform CImage::updateGeometryBuffers () {
     const glm::vec2 previousSize = this->m_size;
     this->m_size = size;
     if (this->m_hasPuppetMesh && size != previousSize) {
-	this->updatePuppetPositionBuffer (size);
+	this->m_puppetSize = size;
+	this->updatePuppetPositionBuffer (size, this->m_puppetRawPositions);
     }
 
     this->updateScenePosition (origin, size, scale, sceneWidth, sceneHeight);

--- a/src/WallpaperEngine/Render/Objects/CImage.h
+++ b/src/WallpaperEngine/Render/Objects/CImage.h
@@ -61,23 +61,33 @@ protected:
 
     void updateScreenSpacePosition ();
 
-    struct ResolvedTransform {
-	glm::vec3 origin;
-	glm::vec3 scale;
-	float angle;
+private:
+    struct PuppetBone {
+	int parent = -1;
+	glm::mat4 inverseBindWorld = glm::mat4 (1.0f);
     };
 
-    [[nodiscard]] ResolvedTransform resolveTransform (const WallpaperEngine::Data::Model::Object& object) const;
+    struct PuppetAnimationFrame {
+	glm::vec3 position = {};
+	glm::vec3 rotation = {};
+	glm::vec3 scale = glm::vec3 (1.0f);
+    };
 
-    /**
-     * Computes the object's own transform (origin/scale/angle) without walking the
-     * parent chain. Used as the per-node step of resolveTransform.
-     */
-    [[nodiscard]] static ResolvedTransform localTransform (const WallpaperEngine::Data::Model::Object& object);
+    struct PuppetAnimation {
+	uint32_t id = 0;
+	std::string name = {};
+	bool loop = true;
+	float fps = 30.0f;
+	/** keyframes indexed [bone][frame] */
+	std::vector<std::vector<PuppetAnimationFrame>> tracks = {};
+    };
 
-private:
     bool loadPuppetMesh (const glm::vec2& size);
-    void updatePuppetPositionBuffer (const glm::vec2& size);
+    bool loadPuppetAnimationData (const std::vector<char>& data, size_t mdlsOffset);
+    void updatePuppetAnimation ();
+    void evaluatePuppetSkin (const PuppetAnimation& animation, float framePosition, std::vector<glm::mat4>& skin) const;
+    [[nodiscard]] glm::vec2 computePuppetCanvasSize (const glm::vec2& size) const;
+    void updatePuppetPositionBuffer (const glm::vec2& size, const std::vector<GLfloat>& rawPositions);
     void setupPuppetGeometryCallback (Effects::CPass* pass) const;
     ResolvedTransform updateGeometryBuffers ();
     [[nodiscard]] glm::vec2 resolveGeometrySize (float sceneWidth, float sceneHeight, glm::vec3& origin) const;
@@ -103,6 +113,12 @@ private:
     GLsizei m_puppetIndexCount = 0;
     bool m_hasPuppetMesh = false;
     std::vector<GLfloat> m_puppetRawPositions = {};
+    std::vector<glm::uvec4> m_puppetVertexBones = {};
+    std::vector<glm::vec4> m_puppetVertexWeights = {};
+    std::vector<GLfloat> m_puppetSkinnedPositions = {};
+    std::vector<PuppetBone> m_puppetBones = {};
+    std::vector<PuppetAnimation> m_puppetAnimations = {};
+    glm::vec2 m_puppetSize = {};
 
     glm::mat4 m_modelViewProjectionScreen = {};
     glm::mat4 m_modelViewProjectionPass = {};

--- a/src/WallpaperEngine/Render/Objects/CText.cpp
+++ b/src/WallpaperEngine/Render/Objects/CText.cpp
@@ -206,7 +206,7 @@ unsigned int CText::computeEffectivePixelSize () const {
     // pointsize, would rasterize glyphs to ~2px on screen (invisible). Rasterize
     // at higher resolution so that after the model scale is applied in render()
     // the on-screen size matches the intended pointsize.
-    const glm::vec3 initialScale = m_text.scale->value->getVec3 ();
+    const glm::vec3 initialScale = this->resolveTransform (m_text).scale;
     const float avgScale = (initialScale.x + initialScale.y) * 0.5f;
     const float compensate = (avgScale > 0.0f && avgScale < 1.0f) ? std::min (1.0f / avgScale, 32.0f) : 1.0f;
     return std::max<unsigned int> (1u, static_cast<unsigned int> (m_text.pointSize->value->getFloat () * compensate));
@@ -337,18 +337,20 @@ void CText::buildShader () {
 }
 
 void CText::uploadQuadVertices () {
-    // Quad centered at the origin, sized in pixels. Scene-space placement is
-    // done via the model matrix using the object's origin/scale. VBO contents
-    // are re-uploaded whenever the glyph bitmap is rebuilt so the quad always
-    // matches the current texture dimensions.
+    // Quad horizontally centered on the origin with its TOP edge at the origin —
+    // WE text boxes anchor at the top and grow downward (clock widgets stack lines
+    // by offsetting origins one text-height apart). Scene-space placement is done
+    // via the model matrix using the object's origin/scale. VBO contents are
+    // re-uploaded whenever the glyph bitmap is rebuilt so the quad always matches
+    // the current texture dimensions.
     const float hx = m_quadSize.x * 0.5f;
-    const float hy = m_quadSize.y * 0.5f;
-    // With vflip=true (Wayland/GLFW), GL y- = screen top. So the quad bottom (y=-hy,
+    const float sy = m_quadSize.y;
+    // With vflip=true (Wayland/GLFW), GL y- = screen top. So the quad bottom (y=0,
     // lower GL y) appears at screen top. UV.v=0 here = FT glyph top → shows at screen top ✓
     const float verts[] = {
 	// pos        // uv
-	-hx, -hy, 0.0f, 0.0f, hx, -hy, 1.0f, 0.0f, hx,  hy, 1.0f, 1.0f,
-	-hx, -hy, 0.0f, 0.0f, hx, hy,  1.0f, 1.0f, -hx, hy, 0.0f, 1.0f,
+	-hx, 0.0f, 0.0f, 0.0f, hx, 0.0f, 1.0f, 0.0f, hx,  sy, 1.0f, 1.0f,
+	-hx, 0.0f, 0.0f, 0.0f, hx, sy,  1.0f, 1.0f, -hx, sy, 0.0f, 1.0f,
     };
 
     const bool firstUpload = (m_vao == 0);
@@ -404,25 +406,26 @@ void CText::render () {
 
     const glm::vec4 color = m_text.color->value->getVec4 ();
     const float alpha = m_text.alpha->value->getFloat ();
-    const glm::vec3 scale = m_text.scale->value->getVec3 ();
-    const glm::vec3 origin = m_text.origin->value->getVec3 ();
+
+    // Text objects can be parented to other objects (e.g. clock widgets composed of
+    // several text layers); resolve origin/scale/angle through the parent chain.
+    const auto transform = this->resolveTransform (m_text);
 
     // WE uses a Y-down coordinate system (origin at top-left, y increases downward).
     // The final FBO is presented to screen with vflip=true on Wayland/GLFW, which maps
-    // GL y- to screen top and GL y+ to screen bottom. This effectively inverts Y again,
-    // so we need: gl_y = origin.y - scene_h/2  (not the CImage-style scene_h/2 - origin.y).
-    // CImage pre-compensates for X11 (no vflip) and gets corrected by the Wayland vflip.
-    // CText renders with direct vflip-aware coordinates.
+    // GL y- to screen top and GL y+ to screen bottom. This matches CImage's mapping:
+    // gl_y = scene_h/2 - origin.y, corrected back by the vflip on presentation.
     const float scene_w = getScene ().getCamera ().getWidth ();
     const float scene_h = getScene ().getCamera ().getHeight ();
     const glm::vec3 gl_origin = {
-	origin.x - scene_w * 0.5f,
-	origin.y - scene_h * 0.5f,
-	origin.z,
+	transform.origin.x - scene_w * 0.5f,
+	scene_h * 0.5f - transform.origin.y,
+	transform.origin.z,
     };
 
     glm::mat4 model = glm::translate (glm::mat4 (1.0f), gl_origin);
-    model = glm::scale (model, scale);
+    model = glm::rotate (model, transform.angle, glm::vec3 (0.0f, 0.0f, 1.0f));
+    model = glm::scale (model, transform.scale);
 
     const glm::mat4 mvp = getScene ().getCamera ().getProjection () * getScene ().getCamera ().getLookAt () * model;
 


### PR DESCRIPTION
## ⚠️ AI-assisted contribution — please review thoroughly

This work was done with heavy AI assistance (Claude). I'm not an expert in this codebase or graphics programming, so a careful review is needed before this goes anywhere. Opening as a draft to gather feedback.

## What this does

Implements skeletal animation for puppet warp images, so wallpapers with animated characters render assembled and animated instead of showing the disassembled "sprite sheet" layout.

### Reverse-engineered format details
- **MDLV** vertex layouts: v0013 (52-byte stride: pos@0, bone indices@12, weights@28, uv@44) and v0021/0023 (80-byte stride: pos@0, bone indices@40, weights@56, uv@72)
- **MDLS** skeleton (v0001/v0003): 78-byte bone records (name, flags, parent, 4x4 bind matrix); v0003 trailing data (cloth constraints?) is skipped
- **MDLA** animations (v0001/v0006): per-bone keyframe tracks of 9 floats (position/rotation/scale); animations are separated by a zero footer; the id matches the object's `animationlayers` entries
- The uint32 after each section marker is the absolute offset of the next section

### Rendering
- CPU skinning (4 bone influences/vertex) updates the puppet position buffer each frame; animation selected from the object's `animationlayers` (id, rate, visible)
- Skinned z is flattened to 0 — bone rotations around x/y otherwise push vertices out of the FBO ortho \[-1, 1\] clip range and slice the mesh
- x/z rotation angles are negated (animations authored in WE's y-down space; mesh is y-up)
- `autosize`: the canvas grows to fit the skinned mesh across all animation frames so animated limbs don't clip at FBO edges
- `cropoffset` is treated as editor-only metadata; applying it as a quad/mesh offset misplaced multi-piece characters
- `resolveTransform`/`localTransform` moved from CImage to CObject and used by CText so text objects honor parent chains (fixes clock widgets built from parented text layers)

### Parser fixes (previously crashing/failing wallpapers)
- `orthogonalprojection` optional, flexible text `padding` formats, optional text property values, `cropoffset` model field

Also adds a nix flake dev shell (separate commit) for building on NixOS.

## Tested against real Wallpaper Engine side-by-side
- **2639381674** (skeleton/zombie): fully assembled + animating, matches WE
- **3294687155** (Midra, Lord of Frenzied Flame): all five puppet pieces (head/body/arm/weapon/cape) assemble and animate correctly, matches WE composition

## Known not-yet-implemented (out of scope here)
- Cloth simulation (e.g. Midra's cape drapes statically)
- Particle systems used heavily in these scenes (torch/wildfire fire effects)
- Multi-line text and exact text sizing semantics
- Animation layer blending (multiple simultaneous layers, additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)