### PR TITLE
Improve X11 rendering on NVIDIA and multi-monitor desktops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,12 @@ if(X11_SUPPORT_FOUND)
     set(X11_LIBRARIES
         ${X11_LIBRARIES}
         ${X11_Xrandr_LIB})
+
+    if(X11_Xfixes_FOUND)
+        set(X11_LIBRARIES
+            ${X11_LIBRARIES}
+            ${X11_Xfixes_LIB})
+    endif()
     set(X11_SOURCES
         src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
         src/WallpaperEngine/Render/Drivers/Output/X11Output.h
@@ -637,6 +643,10 @@ endif()
 
 if(X11_SUPPORT_FOUND)
     target_compile_definitions(linux-wallpaperengine-lib PUBLIC ENABLE_X11)
+
+    if(X11_Xfixes_FOUND)
+        target_compile_definitions(linux-wallpaperengine-lib PUBLIC HAVE_XFIXES=1)
+    endif()
 
     # make sure some of the X11 functions we'll use are available
     check_function_exists(XSetIOErrorExitHandler HAVE_XSETIOERROREXITHANDLER)

--- a/src/WallpaperEngine/Application/WallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/WallpaperApplication.cpp
@@ -991,6 +991,12 @@ const WallpaperEngine::Render::Drivers::Output::Output& WallpaperApplication::ge
 
 void WallpaperApplication::setDestinationFramebuffer (GLuint framebuffer) {
     this->m_destinationFramebuffer = framebuffer;
+
+    // Video drivers may create their render target before RenderContext is
+    // initialized. Wallpapers added later pick up the stored framebuffer ID.
+    if (this->m_renderContext == nullptr)
+	return;
+
     // Update all wallpapers with the new destination framebuffer
     for (const auto& [screen, wallpaper] : this->m_renderContext->getWallpapers ()) {
 	wallpaper->setDestinationFramebuffer (framebuffer);

--- a/src/WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.cpp
+++ b/src/WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.cpp
@@ -11,6 +11,9 @@
 
 #include <GLFW/glfw3native.h>
 
+#ifdef ENABLE_X11
+#include <X11/Xlib.h>
+#endif
 #include <unistd.h>
 
 using namespace WallpaperEngine::Render::Drivers;
@@ -27,7 +30,9 @@ GLFWOpenGLDriver::GLFWOpenGLDriver (const char* windowTitle, ApplicationContext&
     }
 
     // set some window hints (opengl version to be used)
-    glfwWindowHint (GLFW_SAMPLES, 4);
+    // The desktop path uses its own single-sample render target. Keeping the
+    // hidden GLX drawable tiny and non-multisampled avoids wasting GPU memory.
+    glfwWindowHint (GLFW_SAMPLES, context.settings.render.mode == ApplicationContext::DESKTOP_BACKGROUND ? 0 : 4);
     glfwWindowHint (GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint (GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint (GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
@@ -47,12 +52,26 @@ GLFWOpenGLDriver::GLFWOpenGLDriver (const char* windowTitle, ApplicationContext&
     glfwWindowHint (GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
 #endif /* DEBUG */
 
-    // create window, size doesn't matter as long as we don't show it
-    this->m_window = glfwCreateWindow (640, 480, windowTitle, nullptr, nullptr);
+    const glm::ivec2 initialSize = context.settings.render.mode == ApplicationContext::DESKTOP_BACKGROUND
+	? glm::ivec2 { 64, 64 }
+	: glm::ivec2 { 640, 480 };
+
+    this->m_window = glfwCreateWindow (initialSize.x, initialSize.y, windowTitle, nullptr, nullptr);
 
     if (this->m_window == nullptr) {
 	sLog.exception ("Cannot create window");
     }
+
+#ifdef ENABLE_X11
+    if (context.settings.render.mode == ApplicationContext::DESKTOP_BACKGROUND) {
+	if (Display* display = glfwGetX11Display (); display != nullptr) {
+	    XSetWindowAttributes attributes {};
+	    attributes.override_redirect = True;
+	    XChangeWindowAttributes (display, glfwGetX11Window (this->m_window), CWOverrideRedirect, &attributes);
+	    XFlush (display);
+	}
+    }
+#endif
 
     // make context current, required for glew initialization
     glfwMakeContextCurrent (this->m_window);
@@ -78,7 +97,18 @@ GLFWOpenGLDriver::GLFWOpenGLDriver (const char* windowTitle, ApplicationContext&
 #endif
 }
 
-GLFWOpenGLDriver::~GLFWOpenGLDriver () { glfwTerminate (); }
+GLFWOpenGLDriver::~GLFWOpenGLDriver () {
+    glfwMakeContextCurrent (this->m_window);
+    this->getApp ().setDestinationFramebuffer (0);
+
+    if (this->m_x11ColorBuffer != 0)
+	glDeleteRenderbuffers (1, &this->m_x11ColorBuffer);
+    if (this->m_x11Framebuffer != 0)
+	glDeleteFramebuffers (1, &this->m_x11Framebuffer);
+
+    delete this->m_output;
+    glfwTerminate ();
+}
 
 Output::Output& GLFWOpenGLDriver::getOutput () { return *this->m_output; }
 
@@ -91,6 +121,44 @@ void GLFWOpenGLDriver::resizeWindow (glm::ivec2 size) { glfwSetWindowSize (this-
 void GLFWOpenGLDriver::resizeWindow (glm::ivec4 sizeandpos) {
     glfwSetWindowPos (this->m_window, sizeandpos.x, sizeandpos.y);
     glfwSetWindowSize (this->m_window, sizeandpos.z, sizeandpos.w);
+}
+
+void GLFWOpenGLDriver::ensureX11RenderTargetSize (glm::ivec2 size) {
+    if (size.x <= 0 || size.y <= 0)
+	sLog.exception ("Invalid X11 render target size: ", size.x, "x", size.y);
+
+    if (this->m_x11Framebuffer != 0 && this->m_x11RenderTargetSize == size)
+	return;
+
+    GLint previousFramebuffer = 0;
+    GLint previousRenderbuffer = 0;
+    glGetIntegerv (GL_FRAMEBUFFER_BINDING, &previousFramebuffer);
+    glGetIntegerv (GL_RENDERBUFFER_BINDING, &previousRenderbuffer);
+
+    if (this->m_x11ColorBuffer != 0)
+	glDeleteRenderbuffers (1, &this->m_x11ColorBuffer);
+    if (this->m_x11Framebuffer != 0)
+	glDeleteFramebuffers (1, &this->m_x11Framebuffer);
+
+    glGenFramebuffers (1, &this->m_x11Framebuffer);
+    glBindFramebuffer (GL_FRAMEBUFFER, this->m_x11Framebuffer);
+    glGenRenderbuffers (1, &this->m_x11ColorBuffer);
+    glBindRenderbuffer (GL_RENDERBUFFER, this->m_x11ColorBuffer);
+    glRenderbufferStorage (GL_RENDERBUFFER, GL_RGBA8, size.x, size.y);
+    glFramebufferRenderbuffer (GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, this->m_x11ColorBuffer);
+    glDrawBuffer (GL_COLOR_ATTACHMENT0);
+    glReadBuffer (GL_COLOR_ATTACHMENT0);
+
+    if (glCheckFramebufferStatus (GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+	sLog.exception ("Cannot create the X11 composition framebuffer at ", size.x, "x", size.y);
+
+    this->m_x11RenderTargetSize = size;
+    this->getApp ().setDestinationFramebuffer (this->m_x11Framebuffer);
+
+    glBindRenderbuffer (GL_RENDERBUFFER, static_cast<GLuint> (previousRenderbuffer));
+    glBindFramebuffer (GL_FRAMEBUFFER, static_cast<GLuint> (previousFramebuffer));
+
+    sLog.out ("X11 composition framebuffer: ", size.x, "x", size.y);
 }
 
 void GLFWOpenGLDriver::showWindow () { glfwShowWindow (this->m_window); }
@@ -109,8 +177,20 @@ uint32_t GLFWOpenGLDriver::getFrameCounter () const { return this->m_frameCounte
 
 void GLFWOpenGLDriver::dispatchEventQueue () {
     static float startTime, endTime, minimumTime = 1.0f / this->m_context.settings.render.maximumFPS;
+    const bool useX11Readback = this->m_output->haveImageBuffer ();
     // get the start time of the frame
     startTime = this->getRenderTime ();
+
+    if (useX11Readback) {
+	if (this->m_x11Framebuffer == 0) {
+	    this->ensureX11RenderTargetSize ({ this->m_output->getFullWidth (), this->m_output->getFullHeight () });
+	}
+	glBindFramebuffer (GL_FRAMEBUFFER, this->m_x11Framebuffer);
+	glDrawBuffer (GL_COLOR_ATTACHMENT0);
+    } else {
+	glBindFramebuffer (GL_FRAMEBUFFER, 0);
+    }
+
     // clear the screen
     glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
@@ -119,25 +199,47 @@ void GLFWOpenGLDriver::dispatchEventQueue () {
     }
 
     // read the full texture into the image
-    if (this->m_output->haveImageBuffer ()) {
-	// 4.5 supports glReadnPixels, anything older doesn't...
-	if (GLEW_VERSION_4_5) {
-	    glReadnPixels (
-		0, 0, this->m_output->getFullWidth (), this->m_output->getFullHeight (), GL_BGRA, GL_UNSIGNED_BYTE,
-		this->m_output->getImageBufferSize (), this->m_output->getImageBuffer ()
-	    );
-	} else {
-	    // fallback to old version
-	    glReadPixels (
-		0, 0, this->m_output->getFullWidth (), this->m_output->getFullHeight (), GL_BGRA, GL_UNSIGNED_BYTE,
-		this->m_output->getImageBuffer ()
-	    );
+    if (useX11Readback) {
+	const int fullWidth = this->m_output->getFullWidth ();
+	const int fullHeight = this->m_output->getFullHeight ();
+
+	glBindFramebuffer (GL_READ_FRAMEBUFFER, this->m_x11Framebuffer);
+	glReadBuffer (GL_COLOR_ATTACHMENT0);
+
+	GLint previousPackRowLength = 0;
+	glGetIntegerv (GL_PACK_ROW_LENGTH, &previousPackRowLength);
+	glPixelStorei (GL_PACK_ROW_LENGTH, fullWidth);
+
+	char* imageBuffer = static_cast<char*> (this->m_output->getImageBuffer ());
+	const size_t imageBufferSize = this->m_output->getImageBufferSize ();
+	for (const auto& [screen, viewport] : this->m_output->getViewports ()) {
+	    const int x = viewport->viewport.x;
+	    const int y = viewport->viewport.y;
+	    const int width = viewport->viewport.z;
+	    const int height = viewport->viewport.w;
+	    const size_t offset = (static_cast<size_t> (y) * fullWidth + x) * 4;
+	    if (offset >= imageBufferSize)
+		sLog.exception ("X11 viewport lies outside the composition image buffer");
+
+	    if (GLEW_VERSION_4_5) {
+		glReadnPixels (
+		    x, y, width, height, GL_BGRA, GL_UNSIGNED_BYTE, imageBufferSize - offset, imageBuffer + offset
+		);
+	    } else {
+		glReadPixels (x, y, width, height, GL_BGRA, GL_UNSIGNED_BYTE, imageBuffer + offset);
+	    }
 	}
+
+	glPixelStorei (GL_PACK_ROW_LENGTH, previousPackRowLength);
+	glBindFramebuffer (GL_FRAMEBUFFER, 0);
 
 	GLenum error = glGetError ();
 
 	if (error != GL_NO_ERROR) {
-	    sLog.exception ("OpenGL error when reading texture ", error);
+	    sLog.exception (
+		"OpenGL error when reading the X11 composition framebuffer ", error, " (", fullWidth, "x",
+		fullHeight, ")"
+	    );
 	}
     }
 
@@ -145,8 +247,10 @@ void GLFWOpenGLDriver::dispatchEventQueue () {
     // TODO: AS THOSE, MORE THAN LIKELY, WILL REQUIRE OF A DIFFERENT PROCESSING RATE
     // update the output with the given image
     this->m_output->updateRender ();
-    // do buffer swapping first
-    glfwSwapBuffers (this->m_window);
+    // X11 backgrounds are presented with XPutImage; their tiny hidden GLX
+    // drawable never needs to be swapped.
+    if (!useX11Readback)
+	glfwSwapBuffers (this->m_window);
     // poll for events
     glfwPollEvents ();
     // increase frame counter

--- a/src/WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.h
+++ b/src/WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.h
@@ -33,6 +33,8 @@ public:
     void dispatchEventQueue () override;
     [[nodiscard]] void* getProcAddress (const char* name) const override;
 
+    void ensureX11RenderTargetSize (glm::ivec2 size);
+
     GLFWwindow* getWindow () const;
 
 private:
@@ -40,6 +42,9 @@ private:
     Input::Drivers::GLFWMouseInput m_mouseInput;
     Output::Output* m_output = nullptr;
     GLFWwindow* m_window = nullptr;
+    GLuint m_x11Framebuffer = 0;
+    GLuint m_x11ColorBuffer = 0;
+    glm::ivec2 m_x11RenderTargetSize = { 0, 0 };
     uint32_t m_frameCounter = 0;
 };
 } // namespace WallpaperEngine::Render::Drivers

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
@@ -31,6 +31,13 @@ bool supportsBGRAReadback (const XImage* image, int width) {
     return image != nullptr && image->bits_per_pixel == 32
 	&& image->bytes_per_line == static_cast<long> (width) * 4;
 }
+
+uint32_t checkedImageSize (const XImage* image) {
+    const size_t imageBytes = static_cast<size_t> (image->bytes_per_line) * image->height;
+    if (imageBytes > std::numeric_limits<uint32_t>::max ())
+	sLog.exception ("X11 composition image exceeds the supported buffer size");
+    return static_cast<uint32_t> (imageBytes);
+}
 } // namespace
 
 void CustomXIOErrorExitHandler (Display*, void*) {
@@ -76,52 +83,9 @@ void X11Output::free () {
     this->m_viewports.clear ();
 
     if (this->m_display != nullptr) {
-	for (const auto& [name, gc] : this->m_windowGCs) {
-	    if (gc != None)
-		XFreeGC (this->m_display, gc);
-	}
-
-	for (const auto& [name, window] : this->m_windows) {
-	    if (window != None)
-		XDestroyWindow (this->m_display, window);
-	}
-
-	if (this->m_image != nullptr) {
-	    if (this->m_useShm) {
-		char* shmAddress = this->m_shmInfo.shmaddr;
-		XShmDetach (this->m_display, &this->m_shmInfo);
-		XSync (this->m_display, False);
-		// The shared segment is detached separately; never pass it to free().
-		this->m_image->data = nullptr;
-		XDestroyImage (this->m_image);
-		if (shmAddress != nullptr && shmAddress != reinterpret_cast<char*> (-1))
-		    shmdt (shmAddress);
-	    } else {
-		// XDestroyImage owns and frees m_imageData for the fallback image.
-		XDestroyImage (this->m_image);
-	    }
-	    this->m_image = nullptr;
-	    this->m_imageData = nullptr;
-	} else if (this->m_imageData != nullptr) {
-	    std::free (this->m_imageData);
-	    this->m_imageData = nullptr;
-	}
-
-	if (this->m_gc != None)
-	    XFreeGC (this->m_display, this->m_gc);
-	if (this->m_pixmap != None) {
-	    // The root properties must never retain the XID after its pixmap is freed.
-	    XSetWindowBackground (
-		this->m_display, this->m_root, BlackPixel (this->m_display, DefaultScreen (this->m_display))
-	    );
-	    if (this->m_rootPixmapAtom != None)
-		XDeleteProperty (this->m_display, this->m_root, this->m_rootPixmapAtom);
-	    if (this->m_esetrootPixmapAtom != None)
-		XDeleteProperty (this->m_display, this->m_root, this->m_esetrootPixmapAtom);
-	    XClearWindow (this->m_display, this->m_root);
-	    XFreePixmap (this->m_display, this->m_pixmap);
-	}
-
+	this->freePerOutputWindows ();
+	this->freeImageBuffer ();
+	this->freeRootPixmap ();
 	XCloseDisplay (this->m_display);
     }
 
@@ -138,6 +102,61 @@ void X11Output::free () {
     this->m_useShm = false;
     this->m_shmInfo = {};
     this->m_lastRootSync = {};
+}
+
+void X11Output::freePerOutputWindows () {
+    for (const auto& [name, gc] : this->m_windowGCs) {
+	if (gc != None)
+	    XFreeGC (this->m_display, gc);
+    }
+
+    for (const auto& [name, window] : this->m_windows) {
+	if (window != None)
+	    XDestroyWindow (this->m_display, window);
+    }
+}
+
+void X11Output::freeImageBuffer () {
+    if (this->m_image == nullptr) {
+	std::free (this->m_imageData);
+	this->m_imageData = nullptr;
+	return;
+    }
+
+    if (this->m_useShm) {
+	char* shmAddress = this->m_shmInfo.shmaddr;
+	XShmDetach (this->m_display, &this->m_shmInfo);
+	XSync (this->m_display, False);
+	// The shared segment is detached separately; never pass it to free().
+	this->m_image->data = nullptr;
+	XDestroyImage (this->m_image);
+	if (shmAddress != nullptr && shmAddress != reinterpret_cast<char*> (-1))
+	    shmdt (shmAddress);
+    } else {
+	// XDestroyImage owns and frees m_imageData for the fallback image.
+	XDestroyImage (this->m_image);
+    }
+
+    this->m_image = nullptr;
+    this->m_imageData = nullptr;
+}
+
+void X11Output::freeRootPixmap () {
+    if (this->m_gc != None)
+	XFreeGC (this->m_display, this->m_gc);
+    if (this->m_pixmap == None)
+	return;
+
+    // The root properties must never retain the XID after its pixmap is freed.
+    XSetWindowBackground (
+	this->m_display, this->m_root, BlackPixel (this->m_display, DefaultScreen (this->m_display))
+    );
+    if (this->m_rootPixmapAtom != None)
+	XDeleteProperty (this->m_display, this->m_root, this->m_rootPixmapAtom);
+    if (this->m_esetrootPixmapAtom != None)
+	XDeleteProperty (this->m_display, this->m_root, this->m_esetrootPixmapAtom);
+    XClearWindow (this->m_display, this->m_root);
+    XFreePixmap (this->m_display, this->m_pixmap);
 }
 
 void* X11Output::getImageBuffer () const { return this->m_imageData; }
@@ -372,61 +391,88 @@ void X11Output::initX11Background () {
 }
 
 void X11Output::initImageBuffer (unsigned int depth) {
-    const int screen = DefaultScreen (this->m_display);
+    if (this->initShmImageBuffer (depth))
+	return;
 
-    if (XShmQueryExtension (this->m_display)) {
-	this->m_image = XShmCreateImage (
-	    this->m_display, DefaultVisual (this->m_display, screen), depth, ZPixmap, nullptr, &this->m_shmInfo,
-	    this->m_fullWidth, this->m_fullHeight
+    this->initFallbackImageBuffer (depth);
+}
+
+bool X11Output::initShmImageBuffer (unsigned int depth) {
+    if (!XShmQueryExtension (this->m_display))
+	return false;
+
+    const int screen = DefaultScreen (this->m_display);
+    this->m_shmInfo = {};
+    this->m_shmInfo.shmid = -1;
+    this->m_image = XShmCreateImage (
+	this->m_display, DefaultVisual (this->m_display, screen), depth, ZPixmap, nullptr, &this->m_shmInfo,
+	this->m_fullWidth, this->m_fullHeight
+    );
+    if (this->m_image == nullptr)
+	return false;
+
+    if (!supportsBGRAReadback (this->m_image, this->m_fullWidth)) {
+	sLog.error (
+	    "MIT-SHM image layout is incompatible with BGRA readback (", this->m_image->bits_per_pixel,
+	    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line)"
 	);
-	if (this->m_image != nullptr) {
-	    if (!supportsBGRAReadback (this->m_image, this->m_fullWidth)) {
-		sLog.error (
-		    "MIT-SHM image layout is incompatible with BGRA readback (", this->m_image->bits_per_pixel,
-		    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line)"
-		);
-		XDestroyImage (this->m_image);
-		this->m_image = nullptr;
-	    }
-	}
-	if (this->m_image != nullptr) {
-	    const size_t imageBytes = static_cast<size_t> (this->m_image->bytes_per_line) * this->m_image->height;
-	    if (imageBytes > std::numeric_limits<uint32_t>::max ())
-		sLog.exception ("X11 composition image exceeds the supported buffer size");
-	    this->m_shmInfo.shmid = shmget (IPC_PRIVATE, imageBytes, IPC_CREAT | 0600);
-	    if (this->m_shmInfo.shmid >= 0) {
-		this->m_shmInfo.shmaddr = static_cast<char*> (shmat (this->m_shmInfo.shmid, nullptr, 0));
-		if (this->m_shmInfo.shmaddr != reinterpret_cast<char*> (-1)) {
-		    this->m_shmInfo.readOnly = False;
-		    this->m_image->data = this->m_shmInfo.shmaddr;
-		    trappedXError = false;
-		    trapXErrors = true;
-		    const bool attachRequested = XShmAttach (this->m_display, &this->m_shmInfo);
-		    XSync (this->m_display, False);
-		    trapXErrors = false;
-		    if (attachRequested && !trappedXError) {
-			// Mark it for automatic removal after the final detach.
-			shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
-			this->m_useShm = true;
-			this->m_imageData = this->m_shmInfo.shmaddr;
-			this->m_imageSize = static_cast<uint32_t> (imageBytes);
-			std::fill_n (this->m_imageData, imageBytes, 0);
-			sLog.out ("Using MIT-SHM for X11 frame uploads (", imageBytes, " bytes)");
-			return;
-		    }
-		    if (attachRequested && trappedXError)
-			sLog.error ("X server rejected MIT-SHM attachment; using regular X11 frame uploads");
-		    shmdt (this->m_shmInfo.shmaddr);
-		}
-		shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
-	    }
-	    this->m_image->data = nullptr;
-	    XDestroyImage (this->m_image);
-	    this->m_image = nullptr;
-	    this->m_shmInfo = {};
-	}
+	this->discardShmImageBuffer ();
+	return false;
     }
 
+    const uint32_t imageBytes = checkedImageSize (this->m_image);
+    this->m_shmInfo.shmid = shmget (IPC_PRIVATE, imageBytes, IPC_CREAT | 0600);
+    if (this->m_shmInfo.shmid < 0) {
+	this->discardShmImageBuffer ();
+	return false;
+    }
+
+    this->m_shmInfo.shmaddr = static_cast<char*> (shmat (this->m_shmInfo.shmid, nullptr, 0));
+    if (this->m_shmInfo.shmaddr == reinterpret_cast<char*> (-1)) {
+	this->discardShmImageBuffer ();
+	return false;
+    }
+
+    this->m_shmInfo.readOnly = False;
+    this->m_image->data = this->m_shmInfo.shmaddr;
+    trappedXError = false;
+    trapXErrors = true;
+    const bool attachRequested = XShmAttach (this->m_display, &this->m_shmInfo);
+    XSync (this->m_display, False);
+    trapXErrors = false;
+
+    if (!attachRequested || trappedXError) {
+	if (attachRequested)
+	    sLog.error ("X server rejected MIT-SHM attachment; using regular X11 frame uploads");
+	this->discardShmImageBuffer ();
+	return false;
+    }
+
+    // Mark it for automatic removal after the final detach.
+    shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
+    this->m_useShm = true;
+    this->m_imageData = this->m_shmInfo.shmaddr;
+    this->m_imageSize = imageBytes;
+    std::fill_n (this->m_imageData, imageBytes, 0);
+    sLog.out ("Using MIT-SHM for X11 frame uploads (", imageBytes, " bytes)");
+    return true;
+}
+
+void X11Output::discardShmImageBuffer () {
+    if (this->m_shmInfo.shmaddr != nullptr && this->m_shmInfo.shmaddr != reinterpret_cast<char*> (-1))
+	shmdt (this->m_shmInfo.shmaddr);
+    if (this->m_shmInfo.shmid >= 0)
+	shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
+    if (this->m_image != nullptr) {
+	this->m_image->data = nullptr;
+	XDestroyImage (this->m_image);
+	this->m_image = nullptr;
+    }
+    this->m_shmInfo = {};
+}
+
+void X11Output::initFallbackImageBuffer (unsigned int depth) {
+    const int screen = DefaultScreen (this->m_display);
     this->m_image = XCreateImage (
 	this->m_display, DefaultVisual (this->m_display, screen), depth, ZPixmap, 0, nullptr,
 	this->m_fullWidth, this->m_fullHeight, 32, 0
@@ -439,11 +485,8 @@ void X11Output::initImageBuffer (unsigned int depth) {
 	    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line)"
 	);
 
-    const size_t imageBytes = static_cast<size_t> (this->m_image->bytes_per_line) * this->m_image->height;
-    if (imageBytes > std::numeric_limits<uint32_t>::max ())
-	sLog.exception ("X11 composition image exceeds the supported buffer size");
-    this->m_imageSize = static_cast<uint32_t> (imageBytes);
-    this->m_imageData = static_cast<char*> (std::calloc (imageBytes, 1));
+    this->m_imageSize = checkedImageSize (this->m_image);
+    this->m_imageData = static_cast<char*> (std::calloc (this->m_imageSize, 1));
     if (this->m_imageData == nullptr)
 	sLog.exception ("Cannot allocate the X11 image buffer");
     this->m_image->data = this->m_imageData;

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
+#include <limits>
 #include <ranges>
 
 #include <sys/ipc.h>
@@ -22,6 +23,16 @@
 
 using namespace WallpaperEngine::Render::Drivers::Output;
 
+namespace {
+thread_local bool trapXErrors = false;
+thread_local bool trappedXError = false;
+
+bool supportsBGRAReadback (const XImage* image, int width) {
+    return image != nullptr && image->bits_per_pixel == 32
+	&& image->bytes_per_line == static_cast<long> (width) * 4;
+}
+} // namespace
+
 void CustomXIOErrorExitHandler (Display*, void* userdata) {
     const auto context = static_cast<X11Output*> (userdata);
     sLog.debugerror ("Critical XServer error detected. Attempting to recover...");
@@ -29,6 +40,11 @@ void CustomXIOErrorExitHandler (Display*, void* userdata) {
 }
 
 int CustomXErrorHandler (Display*, XErrorEvent*) {
+    if (trapXErrors) {
+	trappedXError = true;
+	return 0;
+    }
+
     sLog.debugerror ("Detected X error");
     return 0;
 }
@@ -92,8 +108,18 @@ void X11Output::free () {
 
 	if (this->m_gc != None)
 	    XFreeGC (this->m_display, this->m_gc);
-	if (this->m_pixmap != None)
+	if (this->m_pixmap != None) {
+	    // The root properties must never retain the XID after its pixmap is freed.
+	    XSetWindowBackground (
+		this->m_display, this->m_root, BlackPixel (this->m_display, DefaultScreen (this->m_display))
+	    );
+	    if (this->m_rootPixmapAtom != None)
+		XDeleteProperty (this->m_display, this->m_root, this->m_rootPixmapAtom);
+	    if (this->m_esetrootPixmapAtom != None)
+		XDeleteProperty (this->m_display, this->m_root, this->m_esetrootPixmapAtom);
+	    XClearWindow (this->m_display, this->m_root);
 	    XFreePixmap (this->m_display, this->m_pixmap);
+	}
 
 	XCloseDisplay (this->m_display);
     }
@@ -353,15 +379,31 @@ void X11Output::initImageBuffer (unsigned int depth) {
 	    this->m_fullWidth, this->m_fullHeight
 	);
 	if (this->m_image != nullptr) {
+	    if (!supportsBGRAReadback (this->m_image, this->m_fullWidth)) {
+		sLog.error (
+		    "MIT-SHM image layout is incompatible with BGRA readback (", this->m_image->bits_per_pixel,
+		    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line)"
+		);
+		XDestroyImage (this->m_image);
+		this->m_image = nullptr;
+	    }
+	}
+	if (this->m_image != nullptr) {
 	    const size_t imageBytes = static_cast<size_t> (this->m_image->bytes_per_line) * this->m_image->height;
+	    if (imageBytes > std::numeric_limits<uint32_t>::max ())
+		sLog.exception ("X11 composition image exceeds the supported buffer size");
 	    this->m_shmInfo.shmid = shmget (IPC_PRIVATE, imageBytes, IPC_CREAT | 0600);
 	    if (this->m_shmInfo.shmid >= 0) {
 		this->m_shmInfo.shmaddr = static_cast<char*> (shmat (this->m_shmInfo.shmid, nullptr, 0));
 		if (this->m_shmInfo.shmaddr != reinterpret_cast<char*> (-1)) {
 		    this->m_shmInfo.readOnly = False;
 		    this->m_image->data = this->m_shmInfo.shmaddr;
-		    if (XShmAttach (this->m_display, &this->m_shmInfo)) {
-			XSync (this->m_display, False);
+		    trappedXError = false;
+		    trapXErrors = true;
+		    const bool attachRequested = XShmAttach (this->m_display, &this->m_shmInfo);
+		    XSync (this->m_display, False);
+		    trapXErrors = false;
+		    if (attachRequested && !trappedXError) {
 			// Mark it for automatic removal after the final detach.
 			shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
 			this->m_useShm = true;
@@ -371,6 +413,8 @@ void X11Output::initImageBuffer (unsigned int depth) {
 			sLog.out ("Using MIT-SHM for X11 frame uploads (", imageBytes, " bytes)");
 			return;
 		    }
+		    if (attachRequested && trappedXError)
+			sLog.error ("X server rejected MIT-SHM attachment; using regular X11 frame uploads");
 		    shmdt (this->m_shmInfo.shmaddr);
 		}
 		shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
@@ -382,17 +426,26 @@ void X11Output::initImageBuffer (unsigned int depth) {
 	}
     }
 
-    this->m_imageSize = static_cast<uint32_t> (this->m_fullWidth) * static_cast<uint32_t> (this->m_fullHeight) * 4;
-    this->m_imageData = static_cast<char*> (std::calloc (this->m_imageSize, 1));
-    if (this->m_imageData == nullptr)
-	sLog.exception ("Cannot allocate the X11 image buffer");
-
     this->m_image = XCreateImage (
-	this->m_display, DefaultVisual (this->m_display, screen), depth, ZPixmap, 0, this->m_imageData,
+	this->m_display, DefaultVisual (this->m_display, screen), depth, ZPixmap, 0, nullptr,
 	this->m_fullWidth, this->m_fullHeight, 32, 0
     );
     if (this->m_image == nullptr)
 	sLog.exception ("Cannot create the X11 image");
+    if (!supportsBGRAReadback (this->m_image, this->m_fullWidth))
+	sLog.exception (
+	    "X11 image layout is incompatible with BGRA readback (", this->m_image->bits_per_pixel,
+	    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line)"
+	);
+
+    const size_t imageBytes = static_cast<size_t> (this->m_image->bytes_per_line) * this->m_image->height;
+    if (imageBytes > std::numeric_limits<uint32_t>::max ())
+	sLog.exception ("X11 composition image exceeds the supported buffer size");
+    this->m_imageSize = static_cast<uint32_t> (imageBytes);
+    this->m_imageData = static_cast<char*> (std::calloc (imageBytes, 1));
+    if (this->m_imageData == nullptr)
+	sLog.exception ("Cannot allocate the X11 image buffer");
+    this->m_image->data = this->m_imageData;
 
     sLog.out ("MIT-SHM unavailable; using regular X11 frame uploads");
 }

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
@@ -29,7 +29,9 @@ thread_local bool trappedXError = false;
 
 bool supportsBGRAReadback (const XImage* image, int width) {
     return image != nullptr && image->bits_per_pixel == 32
-	&& image->bytes_per_line == static_cast<long> (width) * 4;
+	&& image->bytes_per_line == static_cast<long> (width) * 4 && image->byte_order == LSBFirst
+	&& image->red_mask == 0x00FF0000UL && image->green_mask == 0x0000FF00UL
+	&& image->blue_mask == 0x000000FFUL;
 }
 
 uint32_t checkedImageSize (const XImage* image) {
@@ -414,7 +416,9 @@ bool X11Output::initShmImageBuffer (unsigned int depth) {
     if (!supportsBGRAReadback (this->m_image, this->m_fullWidth)) {
 	sLog.error (
 	    "MIT-SHM image layout is incompatible with BGRA readback (", this->m_image->bits_per_pixel,
-	    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line)"
+	    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line, byte order ",
+	    this->m_image->byte_order, ", RGB masks ", this->m_image->red_mask, "/", this->m_image->green_mask,
+	    "/", this->m_image->blue_mask, ")"
 	);
 	this->discardShmImageBuffer ();
 	return false;
@@ -482,7 +486,9 @@ void X11Output::initFallbackImageBuffer (unsigned int depth) {
     if (!supportsBGRAReadback (this->m_image, this->m_fullWidth))
 	sLog.exception (
 	    "X11 image layout is incompatible with BGRA readback (", this->m_image->bits_per_pixel,
-	    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line)"
+	    " bits per pixel, ", this->m_image->bytes_per_line, " bytes per line, byte order ",
+	    this->m_image->byte_order, ", RGB masks ", this->m_image->red_mask, "/", this->m_image->green_mask,
+	    "/", this->m_image->blue_mask, ")"
 	);
 
     this->m_imageSize = checkedImageSize (this->m_image);

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
@@ -1,71 +1,99 @@
 #include "X11Output.h"
 #include "GLFWOutputViewport.h"
 #include "WallpaperEngine/Logging/Log.h"
+#include "WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <ranges>
 
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
+#ifdef HAVE_XFIXES
+#include <X11/extensions/Xfixes.h>
+#include <X11/extensions/shape.h>
+#endif
 
 using namespace WallpaperEngine::Render::Drivers::Output;
 
-void CustomXIOErrorExitHandler (Display* dsp, void* userdata) {
+void CustomXIOErrorExitHandler (Display*, void* userdata) {
     const auto context = static_cast<X11Output*> (userdata);
-
     sLog.debugerror ("Critical XServer error detected. Attempting to recover...");
-
-    // refetch all the resources
     context->reset ();
 }
 
-int CustomXErrorHandler (Display* dpy, XErrorEvent* event) {
+int CustomXErrorHandler (Display*, XErrorEvent*) {
     sLog.debugerror ("Detected X error");
-
     return 0;
 }
 
-int CustomXIOErrorHandler (Display* dsp) {
-    sLog.debugerror ("Detected X error");
-
+int CustomXIOErrorHandler (Display*) {
+    sLog.debugerror ("Detected X I/O error");
     return 0;
 }
 
-X11Output::X11Output (ApplicationContext& context, VideoDriver& driver) :
-    Output (context, driver), m_display (nullptr), m_pixmap (None), m_root (None), m_gc (None), m_imageData (nullptr),
-    m_imageSize (0), m_image (nullptr) {
-    // do not use previous handler, it might stop the app under weird circumstances
+X11Output::X11Output (ApplicationContext& context, VideoDriver& driver) : Output (context, driver) {
     XSetErrorHandler (CustomXErrorHandler);
     XSetIOErrorHandler (CustomXIOErrorHandler);
-
     this->loadScreenInfo ();
 }
 
 X11Output::~X11Output () { this->free (); }
 
 void X11Output::reset () {
-    // first free whatever we have right now
     this->free ();
-    // re-load screen info
     this->loadScreenInfo ();
-    // do the same for the detector
-    // TODO: BRING BACK THIS FUNCTIONALITY
-    // this->m_driver.getFullscreenDetector ().reset ();
 }
 
 void X11Output::free () {
-    // delete owned viewport objects (m_viewports holds non-owning aliases)
-    for (const auto& screen : this->m_screens) {
+    for (const auto* screen : this->m_screens)
 	delete screen;
-    }
 
     this->m_screens.clear ();
     this->m_viewports.clear ();
 
-    // free all the resources we've got
-    XDestroyImage (this->m_image);
-    XFreeGC (this->m_display, this->m_gc);
-    XFreePixmap (this->m_display, this->m_pixmap);
-    delete this->m_imageData;
-    XCloseDisplay (this->m_display);
+    if (this->m_display != nullptr) {
+	for (const auto& [name, gc] : this->m_windowGCs) {
+	    if (gc != None)
+		XFreeGC (this->m_display, gc);
+	}
+
+	for (const auto& [name, window] : this->m_windows) {
+	    if (window != None)
+		XDestroyWindow (this->m_display, window);
+	}
+
+	if (this->m_image != nullptr) {
+	    // XDestroyImage owns and frees m_imageData.
+	    XDestroyImage (this->m_image);
+	    this->m_image = nullptr;
+	    this->m_imageData = nullptr;
+	} else if (this->m_imageData != nullptr) {
+	    std::free (this->m_imageData);
+	    this->m_imageData = nullptr;
+	}
+
+	if (this->m_gc != None)
+	    XFreeGC (this->m_display, this->m_gc);
+	if (this->m_pixmap != None)
+	    XFreePixmap (this->m_display, this->m_pixmap);
+
+	XCloseDisplay (this->m_display);
+    }
+
+    this->m_windowGCs.clear ();
+    this->m_windows.clear ();
+    this->m_display = nullptr;
+    this->m_pixmap = None;
+    this->m_root = None;
+    this->m_gc = None;
+    this->m_rootPixmapAtom = None;
+    this->m_esetrootPixmapAtom = None;
+    this->m_imageSize = 0;
+    this->m_usePerOutputWindows = false;
+    this->m_lastRootSync = {};
 }
 
 void* X11Output::getImageBuffer () const { return this->m_imageData; }
@@ -74,173 +102,351 @@ bool X11Output::renderVFlip () const { return false; }
 
 bool X11Output::renderMultiple () const { return this->m_viewports.size () > 1; }
 
-bool X11Output::haveImageBuffer () const { return true; }
+bool X11Output::haveImageBuffer () const { return this->m_imageData != nullptr; }
 
 uint32_t X11Output::getImageBufferSize () const { return this->m_imageSize; }
 
 void X11Output::loadScreenInfo () {
     this->m_display = XOpenDisplay (nullptr);
-    // set the error handling to try and recover from X disconnections
+    if (this->m_display == nullptr)
+	sLog.exception ("Cannot open the X11 display");
+
 #ifdef HAVE_XSETIOERROREXITHANDLER
     XSetIOErrorExitHandler (this->m_display, CustomXIOErrorExitHandler, this);
-#endif /* HAVE_XSETIOERROREXITHANDLER */
+#endif
 
-    int xrandr_result, xrandr_error;
-
-    if (!XRRQueryExtension (this->m_display, &xrandr_result, &xrandr_error)) {
-	sLog.error ("XRandr is not present, cannot detect specified screens, running in window mode");
-	return;
-    }
+    int eventBase = 0;
+    int errorBase = 0;
+    if (!XRRQueryExtension (this->m_display, &eventBase, &errorBase))
+	sLog.exception ("XRandR is not available; cannot detect X11 outputs");
 
     this->m_root = DefaultRootWindow (this->m_display);
-    this->m_fullWidth = DisplayWidth (this->m_display, DefaultScreen (this->m_display));
-    this->m_fullHeight = DisplayHeight (this->m_display, DefaultScreen (this->m_display));
-    XRRScreenResources* screenResources = XRRGetScreenResources (this->m_display, DefaultRootWindow (this->m_display));
+    this->m_rootWidth = DisplayWidth (this->m_display, DefaultScreen (this->m_display));
+    this->m_rootHeight = DisplayHeight (this->m_display, DefaultScreen (this->m_display));
 
-    if (screenResources == nullptr) {
-	sLog.error ("Cannot detect screen sizes using xrandr, running in window mode");
-	return;
-    }
+    XRRScreenResources* resources = XRRGetScreenResources (this->m_display, this->m_root);
+    if (resources == nullptr)
+	sLog.exception ("Cannot query X11 output sizes with XRandR");
 
-    discoverOutputs (screenResources);
-    XRRFreeScreenResources (screenResources);
-    validateOutputs ();
-    initX11Background ();
+    this->discoverOutputs (resources);
+    XRRFreeScreenResources (resources);
+    this->validateOutputs ();
+    this->initX11Background ();
 }
 
-void X11Output::discoverOutputs (XRRScreenResources* screenResources) {
-    for (int i = 0; i < screenResources->noutput; i++) {
-	const XRROutputInfo* info = XRRGetOutputInfo (this->m_display, screenResources, screenResources->outputs[i]);
+void X11Output::discoverOutputs (XRRScreenResources* resources) {
+    bool haveBounds = false;
+    int minX = 0;
+    int minY = 0;
+    int maxX = 0;
+    int maxY = 0;
 
-	// screen not in use, ignore it
-	if (info == nullptr || info->connection != RR_Connected) {
+    for (int i = 0; i < resources->noutput; ++i) {
+	XRROutputInfo* info = XRRGetOutputInfo (this->m_display, resources, resources->outputs[i]);
+	if (info == nullptr)
+	    continue;
+
+	if (info->connection != RR_Connected) {
+	    XRRFreeOutputInfo (info);
 	    continue;
 	}
 
-	XRRCrtcInfo* crtc = XRRGetCrtcInfo (this->m_display, screenResources, info->crtc);
-
-	// screen not active, ignore it
+	XRRCrtcInfo* crtc = XRRGetCrtcInfo (this->m_display, resources, info->crtc);
 	if (crtc == nullptr) {
+	    XRRFreeOutputInfo (info);
 	    continue;
 	}
 
-	// check if this screen is part of a span group
-	bool inSpanGroup = false;
-	for (const auto& spanGroup : this->m_context.settings.general.spanGroups) {
-	    for (const auto& screen : spanGroup.screens) {
-		if (screen == info->name) {
-		    inSpanGroup = true;
+	bool requested = this->m_context.settings.general.screenBackgrounds.contains (info->name);
+	if (!requested) {
+	    for (const auto& spanGroup : this->m_context.settings.general.spanGroups) {
+		if (std::ranges::find (spanGroup.screens, info->name) != spanGroup.screens.end ()) {
+		    requested = true;
 		    break;
 		}
 	    }
-	    if (inSpanGroup) {
-		break;
-	    }
 	}
 
-	// only keep info of registered screens
-	if (inSpanGroup
-	    || this->m_context.settings.general.screenBackgrounds.find (info->name)
-		!= this->m_context.settings.general.screenBackgrounds.end ()) {
+	if (requested) {
 	    sLog.out (
-		"Found requested screen: ", info->name, " -> ", crtc->x, "x", crtc->y, ":", crtc->width, "x",
-		crtc->height
+		"Found requested X11 output: ", info->name, " -> ", crtc->x, "x", crtc->y, ":", crtc->width,
+		"x", crtc->height
 	    );
 
-	    auto* vp = new GLFWOutputViewport { { crtc->x, crtc->y, crtc->width, crtc->height }, info->name };
-	    vp->globalPosition = { crtc->x, crtc->y };
-	    vp->logicalSize = { crtc->width, crtc->height };
-	    this->m_screens.push_back (vp);
-	    this->m_viewports[info->name] = vp;
+	    auto* viewport = new GLFWOutputViewport { { crtc->x, crtc->y, crtc->width, crtc->height }, info->name };
+	    viewport->globalPosition = { crtc->x, crtc->y };
+	    viewport->logicalSize = { crtc->width, crtc->height };
+	    this->m_screens.push_back (viewport);
+	    this->m_viewports[info->name] = viewport;
+
+	    const int right = crtc->x + static_cast<int> (crtc->width);
+	    const int bottom = crtc->y + static_cast<int> (crtc->height);
+	    if (!haveBounds) {
+		minX = crtc->x;
+		minY = crtc->y;
+		maxX = right;
+		maxY = bottom;
+		haveBounds = true;
+	    } else {
+		minX = std::min (minX, crtc->x);
+		minY = std::min (minY, crtc->y);
+		maxX = std::max (maxX, right);
+		maxY = std::max (maxY, bottom);
+	    }
 	}
 
 	XRRFreeCrtcInfo (crtc);
+	XRRFreeOutputInfo (info);
     }
+
+    if (!haveBounds)
+	return;
+
+    this->m_rootOffsetX = minX;
+    this->m_rootOffsetY = minY;
+    this->m_fullWidth = maxX - minX;
+    this->m_fullHeight = maxY - minY;
+
+    // Render into a compact framebuffer whose origin is the first requested output.
+    for (const auto& [name, viewport] : this->m_viewports) {
+	viewport->viewport.x -= this->m_rootOffsetX;
+	viewport->viewport.y -= this->m_rootOffsetY;
+    }
+
+    sLog.out (
+	"X11 render bounds: ", this->m_fullWidth, "x", this->m_fullHeight, " @ ", this->m_rootOffsetX, "x",
+	this->m_rootOffsetY, " (root ", this->m_rootWidth, "x", this->m_rootHeight, ")"
+    );
 }
 
 void X11Output::validateOutputs () const {
-    bool any = false;
+    if (!this->m_viewports.empty ())
+	return;
 
-    for (const auto& o : this->m_screens) {
-	const auto cur = this->m_context.settings.general.screenBackgrounds.find (o->name);
-
-	if (cur != this->m_context.settings.general.screenBackgrounds.end ()) {
-	    any = true;
-	    break;
-	}
-
-	// also check span groups
-	for (const auto& spanGroup : this->m_context.settings.general.spanGroups) {
-	    for (const auto& screen : spanGroup.screens) {
-		if (screen == o->name) {
-		    any = true;
-		    break;
-		}
-	    }
-	    if (any) {
-		break;
-	    }
-	}
-	if (any) {
-	    break;
-	}
+    sLog.error ("No requested X11 outputs could be initialized");
+    sLog.error ("Requested outputs:");
+    for (const auto& [name, background] : this->m_context.settings.general.screenBackgrounds)
+	sLog.error ("  ", name);
+    for (const auto& spanGroup : this->m_context.settings.general.spanGroups) {
+	for (const auto& name : spanGroup.screens)
+	    sLog.error ("  ", name, " (span)");
     }
-
-    if (!any) {
-	sLog.error ("No outputs could be initialized, please check the parameters and try again");
-	sLog.error ("Detected outputs:");
-
-	for (const auto& o : this->m_screens) {
-	    sLog.error ("  ", o->name);
-	}
-
-	sLog.error ("Requested: ");
-
-	for (const auto& o : this->m_context.settings.general.screenBackgrounds | std::views::keys) {
-	    sLog.error ("  ", o);
-	}
-
-	sLog.exception ("Cannot continue...");
-    }
+    sLog.exception ("Cannot continue");
 }
 
 void X11Output::initX11Background () {
-    // create pixmap so we can draw things in there
-    this->m_pixmap = XCreatePixmap (this->m_display, this->m_root, this->m_fullWidth, this->m_fullHeight, 24);
-    this->m_gc = XCreateGC (this->m_display, this->m_pixmap, 0, nullptr);
-    // pre-fill it with black
-    XFillRectangle (this->m_display, this->m_pixmap, this->m_gc, 0, 0, this->m_fullWidth, this->m_fullHeight);
-    // set the window background as our pixmap
-    XSetWindowBackgroundPixmap (this->m_display, this->m_root, this->m_pixmap);
-    // allocate space for the image's data
-    this->m_imageSize = this->m_fullWidth * this->m_fullHeight * 4;
-    this->m_imageData = new char[this->m_fullWidth * this->m_fullHeight * 4];
-    // create an image so we can copy it over
-    this->m_image = XCreateImage (
-	this->m_display, CopyFromParent, 24, ZPixmap, 0, this->m_imageData, this->m_fullWidth, this->m_fullHeight, 32, 0
+#ifdef HAVE_XFIXES
+    int eventBase = 0;
+    int errorBase = 0;
+    int major = 0;
+    int minor = 0;
+    this->m_usePerOutputWindows = XFixesQueryExtension (this->m_display, &eventBase, &errorBase)
+	&& XFixesQueryVersion (this->m_display, &major, &minor) && major >= 2;
+#endif
+
+    const int screen = DefaultScreen (this->m_display);
+    const unsigned int depth = static_cast<unsigned int> (DefaultDepth (this->m_display, screen));
+
+    if (this->m_usePerOutputWindows)
+	this->initPerOutputWindows ();
+
+    // Always mirror the live frame into the root pixmap. Compositors and
+    // pseudo-transparent clients such as kitty consume these properties even
+    // when the visible wallpaper itself is presented through desktop windows.
+    this->m_pixmap = XCreatePixmap (
+	this->m_display, this->m_root, static_cast<unsigned int> (this->m_rootWidth),
+	static_cast<unsigned int> (this->m_rootHeight), depth
     );
-    // setup driver's render changing the window's size
-    this->m_driver.resizeWindow ({ this->m_fullWidth, this->m_fullHeight });
+    this->m_gc = XCreateGC (this->m_display, this->m_pixmap, 0, nullptr);
+
+    XSetForeground (this->m_display, this->m_gc, BlackPixel (this->m_display, screen));
+    XFillRectangle (
+	this->m_display, this->m_pixmap, this->m_gc, 0, 0, static_cast<unsigned int> (this->m_rootWidth),
+	static_cast<unsigned int> (this->m_rootHeight)
+    );
+
+    this->m_rootPixmapAtom = XInternAtom (this->m_display, "_XROOTPMAP_ID", False);
+    this->m_esetrootPixmapAtom = XInternAtom (this->m_display, "ESETROOT_PMAP_ID", False);
+    auto readPixmapProperty = [&] (Atom property) -> Pixmap {
+	Atom actualType = None;
+	int actualFormat = 0;
+	unsigned long itemCount = 0;
+	unsigned long bytesAfter = 0;
+	unsigned char* data = nullptr;
+	const int result = XGetWindowProperty (
+	    this->m_display, this->m_root, property, 0, 1, False, XA_PIXMAP, &actualType, &actualFormat,
+	    &itemCount, &bytesAfter, &data
+	);
+	Pixmap pixmap = None;
+	if (result == Success && actualType == XA_PIXMAP && actualFormat == 32 && itemCount == 1 && data != nullptr)
+	    pixmap = *reinterpret_cast<Pixmap*> (data);
+	if (data != nullptr)
+	    XFree (data);
+	return pixmap;
+    };
+
+    Pixmap previousPixmap = readPixmapProperty (this->m_rootPixmapAtom);
+    if (previousPixmap == None)
+	previousPixmap = readPixmapProperty (this->m_esetrootPixmapAtom);
+
+    if (previousPixmap != None) {
+	Window pixmapRoot = None;
+	int x = 0;
+	int y = 0;
+	unsigned int width = 0;
+	unsigned int height = 0;
+	unsigned int border = 0;
+	unsigned int pixmapDepth = 0;
+	if (XGetGeometry (
+		this->m_display, previousPixmap, &pixmapRoot, &x, &y, &width, &height, &border, &pixmapDepth
+	    )
+	    && pixmapDepth == depth) {
+	    XCopyArea (
+		this->m_display, previousPixmap, this->m_pixmap, this->m_gc, 0, 0,
+		std::min (width, static_cast<unsigned int> (this->m_rootWidth)),
+		std::min (height, static_cast<unsigned int> (this->m_rootHeight)), 0, 0
+	    );
+	}
+    }
+
+    XSetWindowBackgroundPixmap (this->m_display, this->m_root, this->m_pixmap);
+    XChangeProperty (
+	this->m_display, this->m_root, this->m_rootPixmapAtom, XA_PIXMAP, 32, PropModeReplace,
+	reinterpret_cast<unsigned char*> (&this->m_pixmap), 1
+    );
+    XChangeProperty (
+	this->m_display, this->m_root, this->m_esetrootPixmapAtom, XA_PIXMAP, 32, PropModeReplace,
+	reinterpret_cast<unsigned char*> (&this->m_pixmap), 1
+    );
+
+    this->initImageBuffer (depth);
+
+    if (auto* driver = dynamic_cast<GLFWOpenGLDriver*> (&this->m_driver); driver != nullptr)
+	driver->ensureX11RenderTargetSize ({ this->m_fullWidth, this->m_fullHeight });
+    else
+	sLog.exception ("X11 output requires the GLFW OpenGL driver");
+}
+
+void X11Output::initImageBuffer (unsigned int depth) {
+    const int screen = DefaultScreen (this->m_display);
+
+    this->m_imageSize = static_cast<uint32_t> (this->m_fullWidth) * static_cast<uint32_t> (this->m_fullHeight) * 4;
+    this->m_imageData = static_cast<char*> (std::calloc (this->m_imageSize, 1));
+    if (this->m_imageData == nullptr)
+	sLog.exception ("Cannot allocate the X11 image buffer");
+
+    this->m_image = XCreateImage (
+	this->m_display, DefaultVisual (this->m_display, screen), depth, ZPixmap, 0, this->m_imageData,
+	this->m_fullWidth, this->m_fullHeight, 32, 0
+    );
+    if (this->m_image == nullptr)
+	sLog.exception ("Cannot create the X11 image");
+
+}
+
+void X11Output::initPerOutputWindows () {
+#ifdef HAVE_XFIXES
+    const Atom windowType = XInternAtom (this->m_display, "_NET_WM_WINDOW_TYPE", False);
+    const Atom desktopType = XInternAtom (this->m_display, "_NET_WM_WINDOW_TYPE_DESKTOP", False);
+    const Atom windowState = XInternAtom (this->m_display, "_NET_WM_STATE", False);
+    const Atom stateBelow = XInternAtom (this->m_display, "_NET_WM_STATE_BELOW", False);
+    const Atom stateSticky = XInternAtom (this->m_display, "_NET_WM_STATE_STICKY", False);
+    const Atom stateSkipTaskbar = XInternAtom (this->m_display, "_NET_WM_STATE_SKIP_TASKBAR", False);
+    const Atom stateSkipPager = XInternAtom (this->m_display, "_NET_WM_STATE_SKIP_PAGER", False);
+    const Atom windowDesktop = XInternAtom (this->m_display, "_NET_WM_DESKTOP", False);
+
+    for (const auto& [name, viewport] : this->m_viewports) {
+	XSetWindowAttributes attributes {};
+	attributes.background_pixmap = None;
+
+	const Window window = XCreateWindow (
+	    this->m_display, this->m_root, viewport->globalPosition.x, viewport->globalPosition.y,
+	    static_cast<unsigned int> (viewport->viewport.z), static_cast<unsigned int> (viewport->viewport.w), 0,
+	    CopyFromParent, InputOutput, CopyFromParent, CWBackPixmap, &attributes
+	);
+	XChangeProperty (
+	    this->m_display, window, windowType, XA_ATOM, 32, PropModeReplace,
+	    reinterpret_cast<const unsigned char*> (&desktopType), 1
+	);
+	const Atom states[] = { stateBelow, stateSticky, stateSkipTaskbar, stateSkipPager };
+	XChangeProperty (
+	    this->m_display, window, windowState, XA_ATOM, 32, PropModeReplace,
+	    reinterpret_cast<const unsigned char*> (states), 4
+	);
+	const unsigned long allDesktops = 0xFFFFFFFFUL;
+	XChangeProperty (
+	    this->m_display, window, windowDesktop, XA_CARDINAL, 32, PropModeReplace,
+	    reinterpret_cast<const unsigned char*> (&allDesktops), 1
+	);
+	XStoreName (this->m_display, window, "linux-wallpaperengine desktop");
+
+	const XserverRegion emptyRegion = XFixesCreateRegion (this->m_display, nullptr, 0);
+	XFixesSetWindowShapeRegion (this->m_display, window, ShapeInput, 0, 0, emptyRegion);
+	XFixesDestroyRegion (this->m_display, emptyRegion);
+
+	XMapWindow (this->m_display, window);
+	this->m_windows[name] = window;
+	this->m_windowGCs[name] = XCreateGC (this->m_display, window, 0, nullptr);
+    }
+
+    XFlush (this->m_display);
+#endif
 }
 
 void X11Output::updateRender () const {
-    // put the image back into the screen
-    XPutImage (
-	this->m_display, this->m_pixmap, this->m_gc, this->m_image, 0, 0, 0, 0, this->m_fullWidth, this->m_fullHeight
-    );
+    const auto putImage = [this] (
+	Drawable drawable, GC gc, int sourceX, int sourceY, int destinationX, int destinationY, unsigned int width,
+	unsigned int height
+    ) {
+	XPutImage (
+	    this->m_display, drawable, gc, this->m_image, sourceX, sourceY, destinationX, destinationY, width, height
+	);
+    };
 
-    // _XROOTPMAP_ID & ESETROOT_PMAP_ID allow other programs (compositors) to
-    // edit the background. Without these, other programs will clear the screen.
-    // it also forces the compositor to refresh the background (tested with picom)
-    const Atom prop_root = XInternAtom (this->m_display, "_XROOTPMAP_ID", False);
-    const Atom prop_esetroot = XInternAtom (this->m_display, "ESETROOT_PMAP_ID", False);
-    XChangeProperty (
-	this->m_display, this->m_root, prop_root, XA_PIXMAP, 32, PropModeReplace, (unsigned char*)&this->m_pixmap, 1
-    );
-    XChangeProperty (
-	this->m_display, this->m_root, prop_esetroot, XA_PIXMAP, 32, PropModeReplace, (unsigned char*)&this->m_pixmap, 1
-    );
+    if (this->m_usePerOutputWindows) {
+	for (const auto& [name, viewport] : this->m_viewports) {
+	    const auto window = this->m_windows.find (name);
+	    const auto gc = this->m_windowGCs.find (name);
+	    if (window == this->m_windows.end () || gc == this->m_windowGCs.end ())
+		continue;
 
-    XClearWindow (this->m_display, this->m_root);
+	    putImage (
+		window->second, gc->second, viewport->viewport.x, viewport->viewport.y, 0, 0,
+		static_cast<unsigned int> (viewport->viewport.z), static_cast<unsigned int> (viewport->viewport.w)
+	    );
+	}
+    }
+
+    const auto now = std::chrono::steady_clock::now ();
+    const bool syncRoot = !this->m_usePerOutputWindows || this->m_lastRootSync.time_since_epoch ().count () == 0
+	|| now - this->m_lastRootSync >= std::chrono::seconds (1);
+    if (syncRoot) {
+	// Keep pseudo-transparency and compositor blur compatible, but avoid
+	// uploading an additional full desktop image on every rendered frame.
+	for (const auto& [name, viewport] : this->m_viewports) {
+	    putImage (
+		this->m_pixmap, this->m_gc, viewport->viewport.x, viewport->viewport.y, viewport->globalPosition.x,
+		viewport->globalPosition.y, static_cast<unsigned int> (viewport->viewport.z),
+		static_cast<unsigned int> (viewport->viewport.w)
+	    );
+	    XClearArea (
+		this->m_display, this->m_root, viewport->globalPosition.x, viewport->globalPosition.y,
+		static_cast<unsigned int> (viewport->viewport.z), static_cast<unsigned int> (viewport->viewport.w),
+		False
+	    );
+	}
+
+	Pixmap pixmap = this->m_pixmap;
+	XChangeProperty (
+	    this->m_display, this->m_root, this->m_rootPixmapAtom, XA_PIXMAP, 32, PropModeReplace,
+	    reinterpret_cast<unsigned char*> (&pixmap), 1
+	);
+	XChangeProperty (
+	    this->m_display, this->m_root, this->m_esetrootPixmapAtom, XA_PIXMAP, 32, PropModeReplace,
+	    reinterpret_cast<unsigned char*> (&pixmap), 1
+	);
+	this->m_lastRootSync = now;
+    }
+
     XFlush (this->m_display);
 }

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
@@ -8,9 +8,13 @@
 #include <cstdlib>
 #include <ranges>
 
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
+#include <X11/extensions/XShm.h>
 #ifdef HAVE_XFIXES
 #include <X11/extensions/Xfixes.h>
 #include <X11/extensions/shape.h>
@@ -66,8 +70,19 @@ void X11Output::free () {
 	}
 
 	if (this->m_image != nullptr) {
-	    // XDestroyImage owns and frees m_imageData.
-	    XDestroyImage (this->m_image);
+	    if (this->m_useShm) {
+		char* shmAddress = this->m_shmInfo.shmaddr;
+		XShmDetach (this->m_display, &this->m_shmInfo);
+		XSync (this->m_display, False);
+		// The shared segment is detached separately; never pass it to free().
+		this->m_image->data = nullptr;
+		XDestroyImage (this->m_image);
+		if (shmAddress != nullptr && shmAddress != reinterpret_cast<char*> (-1))
+		    shmdt (shmAddress);
+	    } else {
+		// XDestroyImage owns and frees m_imageData for the fallback image.
+		XDestroyImage (this->m_image);
+	    }
 	    this->m_image = nullptr;
 	    this->m_imageData = nullptr;
 	} else if (this->m_imageData != nullptr) {
@@ -93,6 +108,8 @@ void X11Output::free () {
     this->m_esetrootPixmapAtom = None;
     this->m_imageSize = 0;
     this->m_usePerOutputWindows = false;
+    this->m_useShm = false;
+    this->m_shmInfo = {};
     this->m_lastRootSync = {};
 }
 
@@ -330,6 +347,41 @@ void X11Output::initX11Background () {
 void X11Output::initImageBuffer (unsigned int depth) {
     const int screen = DefaultScreen (this->m_display);
 
+    if (XShmQueryExtension (this->m_display)) {
+	this->m_image = XShmCreateImage (
+	    this->m_display, DefaultVisual (this->m_display, screen), depth, ZPixmap, nullptr, &this->m_shmInfo,
+	    this->m_fullWidth, this->m_fullHeight
+	);
+	if (this->m_image != nullptr) {
+	    const size_t imageBytes = static_cast<size_t> (this->m_image->bytes_per_line) * this->m_image->height;
+	    this->m_shmInfo.shmid = shmget (IPC_PRIVATE, imageBytes, IPC_CREAT | 0600);
+	    if (this->m_shmInfo.shmid >= 0) {
+		this->m_shmInfo.shmaddr = static_cast<char*> (shmat (this->m_shmInfo.shmid, nullptr, 0));
+		if (this->m_shmInfo.shmaddr != reinterpret_cast<char*> (-1)) {
+		    this->m_shmInfo.readOnly = False;
+		    this->m_image->data = this->m_shmInfo.shmaddr;
+		    if (XShmAttach (this->m_display, &this->m_shmInfo)) {
+			XSync (this->m_display, False);
+			// Mark it for automatic removal after the final detach.
+			shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
+			this->m_useShm = true;
+			this->m_imageData = this->m_shmInfo.shmaddr;
+			this->m_imageSize = static_cast<uint32_t> (imageBytes);
+			std::fill_n (this->m_imageData, imageBytes, 0);
+			sLog.out ("Using MIT-SHM for X11 frame uploads (", imageBytes, " bytes)");
+			return;
+		    }
+		    shmdt (this->m_shmInfo.shmaddr);
+		}
+		shmctl (this->m_shmInfo.shmid, IPC_RMID, nullptr);
+	    }
+	    this->m_image->data = nullptr;
+	    XDestroyImage (this->m_image);
+	    this->m_image = nullptr;
+	    this->m_shmInfo = {};
+	}
+    }
+
     this->m_imageSize = static_cast<uint32_t> (this->m_fullWidth) * static_cast<uint32_t> (this->m_fullHeight) * 4;
     this->m_imageData = static_cast<char*> (std::calloc (this->m_imageSize, 1));
     if (this->m_imageData == nullptr)
@@ -342,6 +394,7 @@ void X11Output::initImageBuffer (unsigned int depth) {
     if (this->m_image == nullptr)
 	sLog.exception ("Cannot create the X11 image");
 
+    sLog.out ("MIT-SHM unavailable; using regular X11 frame uploads");
 }
 
 void X11Output::initPerOutputWindows () {
@@ -398,9 +451,17 @@ void X11Output::updateRender () const {
 	Drawable drawable, GC gc, int sourceX, int sourceY, int destinationX, int destinationY, unsigned int width,
 	unsigned int height
     ) {
-	XPutImage (
-	    this->m_display, drawable, gc, this->m_image, sourceX, sourceY, destinationX, destinationY, width, height
-	);
+	if (this->m_useShm) {
+	    XShmPutImage (
+		this->m_display, drawable, gc, this->m_image, sourceX, sourceY, destinationX, destinationY, width,
+		height, False
+	    );
+	} else {
+	    XPutImage (
+		this->m_display, drawable, gc, this->m_image, sourceX, sourceY, destinationX, destinationY, width,
+		height
+	    );
+	}
     };
 
     if (this->m_usePerOutputWindows) {
@@ -448,5 +509,10 @@ void X11Output::updateRender () const {
 	this->m_lastRootSync = now;
     }
 
-    XFlush (this->m_display);
+    // The renderer overwrites this buffer on the next frame, so ensure the X
+    // server has finished consuming shared-memory uploads before returning.
+    if (this->m_useShm)
+	XSync (this->m_display, False);
+    else
+	XFlush (this->m_display);
 }

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.cpp
@@ -33,10 +33,11 @@ bool supportsBGRAReadback (const XImage* image, int width) {
 }
 } // namespace
 
-void CustomXIOErrorExitHandler (Display*, void* userdata) {
-    const auto context = static_cast<X11Output*> (userdata);
-    sLog.debugerror ("Critical XServer error detected. Attempting to recover...");
-    context->reset ();
+void CustomXIOErrorExitHandler (Display*, void*) {
+    // Xlib invokes this immediately before terminating after a connection loss.
+    // The Display is already unusable, so attempting teardown or recovery here
+    // would only issue more requests on the failed connection.
+    sLog.debugerror ("Critical X server connection error detected; exiting");
 }
 
 int CustomXErrorHandler (Display*, XErrorEvent*) {

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.h
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <glm/vec4.hpp>
 #include <map>
 #include <string>
@@ -30,12 +31,24 @@ private:
     void discoverOutputs (XRRScreenResources* screenResources);
     void validateOutputs () const;
     void initX11Background ();
+    void initImageBuffer (unsigned int depth);
+    void initPerOutputWindows ();
     void free ();
 
     Display* m_display = nullptr;
-    Pixmap m_pixmap;
-    Window m_root;
-    GC m_gc;
+    Pixmap m_pixmap = None;
+    Window m_root = None;
+    GC m_gc = None;
+    Atom m_rootPixmapAtom = None;
+    Atom m_esetrootPixmapAtom = None;
+    int m_rootWidth = 0;
+    int m_rootHeight = 0;
+    int m_rootOffsetX = 0;
+    int m_rootOffsetY = 0;
+    bool m_usePerOutputWindows = false;
+    mutable std::chrono::steady_clock::time_point m_lastRootSync = {};
+    std::map<std::string, Window> m_windows = {};
+    std::map<std::string, GC> m_windowGCs = {};
     char* m_imageData = nullptr;
     uint32_t m_imageSize = 0;
     XImage* m_image = nullptr;

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.h
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.h
@@ -33,7 +33,13 @@ private:
     void validateOutputs () const;
     void initX11Background ();
     void initImageBuffer (unsigned int depth);
+    bool initShmImageBuffer (unsigned int depth);
+    void initFallbackImageBuffer (unsigned int depth);
     void initPerOutputWindows ();
+    void freePerOutputWindows ();
+    void freeImageBuffer ();
+    void freeRootPixmap ();
+    void discardShmImageBuffer ();
     void free ();
 
     Display* m_display = nullptr;

--- a/src/WallpaperEngine/Render/Drivers/Output/X11Output.h
+++ b/src/WallpaperEngine/Render/Drivers/Output/X11Output.h
@@ -7,6 +7,7 @@
 
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
+#include <X11/extensions/XShm.h>
 
 #include "Output.h"
 #include "WallpaperEngine/Render/Drivers/VideoDriver.h"
@@ -46,6 +47,8 @@ private:
     int m_rootOffsetX = 0;
     int m_rootOffsetY = 0;
     bool m_usePerOutputWindows = false;
+    bool m_useShm = false;
+    mutable XShmSegmentInfo m_shmInfo = {};
     mutable std::chrono::steady_clock::time_point m_lastRootSync = {};
     std::map<std::string, Window> m_windows = {};
     std::map<std::string, GC> m_windowGCs = {};


### PR DESCRIPTION
## Summary

- render X11 desktop backgrounds through an explicit RGBA8 framebuffer, avoiding black readback from NVIDIA hidden GLX drawables
- use compact multi-monitor render bounds and managed per-output desktop windows with click-through input regions
- keep `_XROOTPMAP_ID` and `ESETROOT_PMAP_ID` synchronized for pseudo-transparency and compositor blur consumers
- use MIT-SHM for local X11 frame uploads, with regular `XPutImage` fallback
- reduce hidden GLX drawable and framebuffer memory overhead and clean up X11/GL resources

## Commit structure

1. `fix(x11): render backgrounds through an offscreen framebuffer`
2. `fix(x11): present wallpapers in per-output desktop windows`
3. `perf(x11): upload frames through MIT-SHM`

## Testing

Tested on Xorg with Cinnamon and an NVIDIA GeForce RTX 4060 Laptop GPU (driver 595.71.05):

- DP-2: 2560x1440 at 0,0
- HDMI-0: 3840x2160 at 2560,0
- verified both outputs render correctly, including the non-zero HDMI offset
- verified normal application windows remain above the wallpaper
- verified root pixmap updates remain available to Kitty/Cinnamon blur consumers
- verified NVDEC remains active for a 4K60 video wallpaper
- Release build succeeds

Observed at 8 FPS in this setup:

- wallpaper process CPU: roughly 50% -> 10-11%
- Xorg CPU: roughly 59% -> mostly 13-17%
- wallpaper RSS: roughly 1.17 GiB -> 657 MiB
- GPU power/temperature during the test: roughly 72 W / 80 C -> 57 W / 72 C

## Remaining validation

This is a draft because the managed desktop-window path has been validated on Cinnamon but still needs coverage on other X11 window managers/compositors and on systems without XFixes/MIT-SHM.