### PR TITLE
fix: don't open audio device when --silent is used

### DIFF
--- a/src/WallpaperEngine/Audio/Drivers/SDLAudioDriver.cpp
+++ b/src/WallpaperEngine/Audio/Drivers/SDLAudioDriver.cpp
@@ -79,6 +79,11 @@ SDLAudioDriver::SDLAudioDriver (
 ) : AudioDriver (applicationContext, detector, recorder), m_audioSpec () {
     this->m_streamListMutex = SDL_CreateMutex ();
 
+    if (!applicationContext.settings.audio.enabled) {
+	sLog.out ("Audio is disabled, not opening any audio device");
+	return;
+    }
+
     if (SDL_InitSubSystem (SDL_INIT_AUDIO) < 0) {
 	sLog.error ("Cannot initialize SDL audio system, SDL_GetError: ", SDL_GetError ());
 	sLog.error ("Continuing without audio support");


### PR DESCRIPTION
`--silent` sets `audio.enabled = false`, but `SDLAudioDriver` still opens an audio device unconditionally and keeps it unpaused, mixing silence forever. This shows up as a permanent `running` PipeWire stream that never lets the sink idle. With Bluetooth headphones as the output this keeps A2DP busy 24/7 and blocks multipoint switching to another device.

Skip audio device initialization entirely when audio is disabled. Sound sources are already gated on the same flag (CSound, CVideo since #605), so nothing else needs the device in silent mode.