### PR TITLE
fix: bind CEF paint to wallpaper texture id (black web wallpapers)

### DIFF
--- a/src/WallpaperEngine/WebBrowser/CEF/RenderHandler.cpp
+++ b/src/WallpaperEngine/WebBrowser/CEF/RenderHandler.cpp
@@ -24,4 +24,6 @@ int RenderHandler::getWidth () const { return this->m_webdata->getWidth (); }
 
 int RenderHandler::getHeight () const { return this->m_webdata->getHeight (); }
 
-GLuint RenderHandler::texture () const { return this->m_webdata->getWallpaperFramebuffer (); }
+// Must be the color texture attached to the wallpaper FBO — not the FBO name
+// itself. Binding the FBO id as GL_TEXTURE_2D leaves the wallpaper black.
+GLuint RenderHandler::texture () const { return this->m_webdata->getWallpaperTexture (); }


### PR DESCRIPTION
## Summary

`RenderHandler::texture()` returned `getWallpaperFramebuffer()` (an FBO name). `OnPaint` bound that id as `GL_TEXTURE_2D` and uploaded CEF pixels into the wrong GL namespace, while compositing samples `getWallpaperTexture()`. Result: many web wallpapers stay black even though CEF is painting correctly.

Fixes #629.

### Change
```cpp
// before
return this->m_webdata->getWallpaperFramebuffer();
// after
return this->m_webdata->getWallpaperTexture();
```

## Test plan

- [ ] Build with CEF enabled
- [ ] Run a known web wallpaper (windowed or desktop)
- [ ] Confirm the page is visible (not black) while CEF processes stay healthy
- [ ] Optional: remote-debug and confirm paint still matches on-screen output