### PR TITLE
fix: CEF startup, link order, and subprocess handoff for web wallpapers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,16 @@ REPLACED_SET_EXECUTABLE_TARGET_PROPERTIES(linux-wallpaperengine-lib)
 add_executable(linux-wallpaperengine
     src/main.cpp)
 
+# libcef must load *before* libc so Chromium's close() interposer can resolve
+# via dlsym(RTLD_NEXT, "close"). Without this, every web wallpaper dies with
+# "close symbol missing" + SIGTRAP (upstream issue #628).
+# Force an early DT_NEEDED entry; --as-needed would otherwise drop it because
+# main.cpp does not reference CEF symbols directly.
+target_link_options(linux-wallpaperengine PRIVATE
+    "LINKER:--push-state,--no-as-needed"
+    "${TARGET_OUTPUT_DIRECTORY}/libcef.so"
+    "LINKER:--pop-state"
+)
 target_link_libraries (linux-wallpaperengine PUBLIC linux-wallpaperengine-lib)
 
 # Install the main executable and shared library via install(TARGETS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(KISSFFT_TEST OFF)
 set(KISSFFT_TOOLS OFF)
 
+# Disable Chromium's setuid sandbox helpers. Default ON: local/AUR builds rarely
+# ship a working setuid chrome-sandbox, and CefInitialize fails without this.
+# Packagers with a proper sandbox helper can configure -DCEF_NO_SANDBOX=OFF.
+option(CEF_NO_SANDBOX "Disable CEF/Chromium process sandbox (needed without setuid chrome-sandbox)" ON)
+
 # Download CEF of specified version for current platform
 # Specify the CEF distribution version.
 set(CEF_VERSION "135.0.17+gcbc1c5b+chromium-135.0.7049.52")
@@ -628,6 +633,13 @@ endif()
 
 target_compile_definitions(linux-wallpaperengine-lib PUBLIC ERRORONLY=${ERRORONLY})
 target_compile_definitions(linux-wallpaperengine-lib PUBLIC DEMOMODE=${DEMOMODE})
+
+if(CEF_NO_SANDBOX)
+    target_compile_definitions(linux-wallpaperengine-lib PUBLIC CEF_NO_SANDBOX)
+    message(STATUS "CEF_NO_SANDBOX=ON (settings.no_sandbox and --no-sandbox/--disable-gpu-sandbox)")
+else()
+    message(STATUS "CEF_NO_SANDBOX=OFF (Chromium sandbox enabled; requires setuid chrome-sandbox)")
+endif()
 
 if (BUILD_TESTING)
     # tests should give as much output as possible

--- a/src/WallpaperEngine/WebBrowser/CEF/BrowserApp.cpp
+++ b/src/WallpaperEngine/WebBrowser/CEF/BrowserApp.cpp
@@ -22,6 +22,13 @@ void BrowserApp::OnBeforeCommandLineProcessing (const CefString& process_type, C
 	"--disable-features",
 	"IsolateOrigins,HardwareMediaKeyHandling,WebContentsOcclusion,RendererCodeIntegrityEnabled,site-per-process"
     );
+    // Pair with settings.no_sandbox in WebBrowserContext — required when
+    // chrome-sandbox is not setuid root (typical non-packaged local build).
+    command_line->AppendSwitch ("--no-sandbox");
+    command_line->AppendSwitch ("--disable-gpu-sandbox");
+    // Avoid a separate GPU process (often fails on Wayland/Hyprland with CEF
+    // windowless rendering — error_code=1002 "GPU process isn't usable").
+    command_line->AppendSwitch ("--in-process-gpu");
     command_line->AppendSwitch ("--disable-gpu-shader-disk-cache");
     command_line->AppendSwitch ("--disable-site-isolation-trials");
     command_line->AppendSwitch ("--disable-web-security");
@@ -47,8 +54,18 @@ if (process_type.empty()) {
 }
 
 void BrowserApp::OnBeforeChildProcessLaunch (CefRefPtr<CefCommandLine> command_line) {
-    // add back any parameters we had before so the new process can load up everything needed
-    for (int i = 1; i < this->getApplication ().getContext ().getArgc (); i++) {
-	command_line->AppendArgument (this->getApplication ().getContext ().getArgv ()[i]);
+    // Do NOT re-append the full wallpaper-engine argv. That used to force every
+    // CEF child to re-enter ApplicationContext/WallpaperApplication (and often
+    // crash). Instead pass only the custom scheme IDs so EarlyCefSubprocessApp
+    // in main.cpp can register matching wp{id} schemes.
+    std::string schemeIds;
+    for (const auto& workshopId : this->getHandlerFactories () | std::views::keys) {
+	if (!schemeIds.empty ()) {
+	    schemeIds.push_back (',');
+	}
+	schemeIds += workshopId;
+    }
+    if (!schemeIds.empty ()) {
+	command_line->AppendSwitchWithValue ("wp-schemes", schemeIds);
     }
 }

--- a/src/WallpaperEngine/WebBrowser/CEF/BrowserApp.cpp
+++ b/src/WallpaperEngine/WebBrowser/CEF/BrowserApp.cpp
@@ -22,10 +22,11 @@ void BrowserApp::OnBeforeCommandLineProcessing (const CefString& process_type, C
 	"--disable-features",
 	"IsolateOrigins,HardwareMediaKeyHandling,WebContentsOcclusion,RendererCodeIntegrityEnabled,site-per-process"
     );
-    // Pair with settings.no_sandbox in WebBrowserContext — required when
-    // chrome-sandbox is not setuid root (typical non-packaged local build).
+    // Pair with settings.no_sandbox in WebBrowserContext (CMake CEF_NO_SANDBOX).
+#if defined(CEF_NO_SANDBOX)
     command_line->AppendSwitch ("--no-sandbox");
     command_line->AppendSwitch ("--disable-gpu-sandbox");
+#endif
     // Avoid a separate GPU process (often fails on Wayland/Hyprland with CEF
     // windowless rendering — error_code=1002 "GPU process isn't usable").
     command_line->AppendSwitch ("--in-process-gpu");

--- a/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp
+++ b/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp
@@ -83,11 +83,13 @@ WebBrowserContext::WebBrowserContext (WallpaperEngine::Application::WallpaperApp
     //  CefString(&settings.browser_subprocess_path) = "path/to/client"
     cef_string_utf8_to_utf16 (cache_path.c_str (), cache_path.length (), &settings.root_cache_path);
     settings.windowless_rendering_enabled = true;
-    // Local builds rarely have chrome-sandbox setuid-root. Without no_sandbox,
-    // CEF dies immediately with "close symbol missing" + SIGTRAP, so every web
-    // wallpaper (including SpaceX Starlink) fails before first paint.
-    // Prefer settings.no_sandbox over relying on CEF_NO_SANDBOX / setuid setup.
+    // Gated by CMake option CEF_NO_SANDBOX (default ON). Local/AUR builds rarely
+    // have chrome-sandbox setuid-root; without no_sandbox, CefInitialize often
+    // dies before the first web wallpaper paint. Packagers with a working
+    // setuid helper can configure -DCEF_NO_SANDBOX=OFF.
+#if defined(CEF_NO_SANDBOX)
     settings.no_sandbox = true;
+#endif
 
     // spawns two new processess
 

--- a/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp
+++ b/src/WallpaperEngine/WebBrowser/WebBrowserContext.cpp
@@ -83,9 +83,11 @@ WebBrowserContext::WebBrowserContext (WallpaperEngine::Application::WallpaperApp
     //  CefString(&settings.browser_subprocess_path) = "path/to/client"
     cef_string_utf8_to_utf16 (cache_path.c_str (), cache_path.length (), &settings.root_cache_path);
     settings.windowless_rendering_enabled = true;
-#if defined(CEF_NO_SANDBOX)
+    // Local builds rarely have chrome-sandbox setuid-root. Without no_sandbox,
+    // CEF dies immediately with "close symbol missing" + SIGTRAP, so every web
+    // wallpaper (including SpaceX Starlink) fails before first paint.
+    // Prefer settings.no_sandbox over relying on CEF_NO_SANDBOX / setuid setup.
     settings.no_sandbox = true;
-#endif
 
     // spawns two new processess
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include "WallpaperEngine/Application/ApplicationContext.h"
 #include "WallpaperEngine/Application/WallpaperApplication.h"
 #include "WallpaperEngine/Logging/Log.h"
+#include "include/cef_app.h"
+#include "include/cef_command_line.h"
 
 WallpaperEngine::Application::WallpaperApplication* app;
 
@@ -20,8 +22,61 @@ void initLogging () {
     sLog.addError (new std::ostream (std::cerr.rdbuf ()));
 }
 
+// Minimal CEF app used when this binary is re-exec'd as a Chromium child
+// (--type=utility/gpu/renderer/...). Going through full WallpaperApplication
+// first breaks those children (arg parse failures / crash loops) so network
+// and GPU services never stay up — web wallpapers stay black.
+//
+// Custom schemes must match the browser process (SubprocessApp). BrowserApp
+// passes them via --wp-schemes=id1,id2 on child launches.
+class EarlyCefSubprocessApp : public CefApp {
+public:
+    void OnRegisterCustomSchemes (CefRawPtr<CefSchemeRegistrar> registrar) override {
+	const CefRefPtr<CefCommandLine> commandLine = CefCommandLine::GetGlobalCommandLine ();
+	if (!commandLine || !commandLine->HasSwitch ("wp-schemes")) {
+	    return;
+	}
+	const std::string schemes = commandLine->GetSwitchValue ("wp-schemes").ToString ();
+	std::size_t start = 0;
+	while (start < schemes.size ()) {
+	    const std::size_t comma = schemes.find (',', start);
+	    const std::string id = schemes.substr (
+		start, comma == std::string::npos ? std::string::npos : comma - start
+	    );
+	    if (!id.empty ()) {
+		// Keep flags in sync with SubprocessApp::OnRegisterCustomSchemes.
+		registrar->AddCustomScheme (
+		    "wp" + id,
+		    CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE | CEF_SCHEME_OPTION_FETCH_ENABLED
+		);
+	    }
+	    if (comma == std::string::npos) {
+		break;
+	    }
+	    start = comma + 1;
+	}
+    }
+
+private:
+    IMPLEMENT_REFCOUNTING (EarlyCefSubprocessApp);
+};
+
 int main (int argc, char* argv[]) {
     try {
+	// Hand off to CEF immediately for Chromium child processes.
+	{
+	    const CefMainArgs main_args (argc, argv);
+	    CefRefPtr<CefCommandLine> commandLine = CefCommandLine::CreateCommandLine ();
+	    commandLine->InitFromArgv (argc, argv);
+	    if (commandLine->HasSwitch ("type")) {
+		CefRefPtr<CefApp> subprocessApp = new EarlyCefSubprocessApp ();
+		const int exit_code = CefExecuteProcess (main_args, subprocessApp, nullptr);
+		if (exit_code >= 0) {
+		    return exit_code;
+		}
+	    }
+	}
+
 	// if type parameter is specified, this is a subprocess, so no logging should be enabled from our side
 	bool enableLogging = true;
 	const std::string typeZygote = "--type=zygote";


### PR DESCRIPTION
## Summary

Web wallpapers often crash at `CefInitialize` or leave children broken so content never appears. This PR groups the non-texture CEF fixes into four commits:

1. **Early `libcef` DT_NEEDED** on the main executable so Chromium’s `close()` interposer can resolve via `dlsym(RTLD_NEXT)` (avoids `close symbol missing` / SIGTRAP). Related to #628.
2. **`settings.no_sandbox = true`** for typical local builds without setuid `chrome-sandbox`.
3. **CEF command-line flags** (`--no-sandbox`, `--disable-gpu-sandbox`, `--in-process-gpu`) and **stop re-appending full wallpaper argv** to CEF children; pass `--wp-schemes` only.
4. **Early `CefExecuteProcess` handoff** in `main` for `--type=...` children with a minimal app that registers matching `wp{id}` schemes.

Together these address startup crashes and broken CEF child processes on local/AUR-style builds (see #628). Pair with the one-line texture fix PR for black-but-alive web wallpapers (#629).

## Test plan

- [ ] Clean rebuild; confirm `readelf -d linux-wallpaperengine` lists `libcef.so` as a direct NEEDED (early)
- [ ] Launch a web wallpaper without `LD_PRELOAD=libcef.so` → no `close symbol missing`
- [ ] Confirm CEF utility/GPU/renderer children stay up (`ps` / logs)
- [ ] Web content paints (with texture fix PR or equivalent)
- [ ] Scene/video wallpapers still work (non-CEF path unchanged)