### PR TITLE
fix(x11): free the correct XQueryTree child list in anythingFullscreen (per-frame memory leak)

### DIFF
--- a/src/WallpaperEngine/Render/Drivers/Detectors/X11FullScreenDetector.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Detectors/X11FullScreenDetector.cpp
@@ -71,11 +71,15 @@ bool X11FullScreenDetector::anythingFullscreen () const {
 	unsigned int num_children;
 
 	if (!XQueryTree (this->m_display, ourWindow, &root, &parentWindow, &schildren, &num_children)) {
+	    XFree (children);
 	    return false;
 	}
 
+	// Free ourWindow's child list — we only queried it to learn parentWindow.
+	// This previously freed `children` (the outer list) by mistake, leaking
+	// schildren every frame and prematurely freeing the list still used below.
 	if (schildren) {
-	    XFree (children);
+	    XFree (schildren);
 	}
     }
 


### PR DESCRIPTION
## Problem

`X11FullScreenDetector::anythingFullscreen()` is called every frame (to pause rendering when another window is fullscreen). It leaks Xlib memory on every call, so RSS grows without bound on X11 sessions — I observed **~8 GB per instance after ~40 hours** on a multi-monitor GNOME/X11 desktop, eventually exhausting RAM + swap.

## Root cause

The function calls `XQueryTree` a second time on our own window solely to obtain `parentWindow`. That call allocates a `schildren` list which must be released with `XFree`. The cleanup frees the **wrong** pointer:

```c
if (schildren) {
    XFree (children);   // frees the OUTER list, not schildren
}
```

So:
- `schildren` is never freed → one window-list leaks **per frame** (the unbounded leak).
- `children` is freed early while the loop below still dereferences `children[i]` (use-after-free), then freed again at the bottom (double-free) whenever our window has children.
- The early `return false` when the inner `XQueryTree` fails also leaks `children`.

## Fix

Free `schildren` in the guard (that is the list we allocated and don't otherwise use), and free `children` on the early-return path. `children` is still freed exactly once at the end, as before.

## Verification (heaptrack)

Same wallpaper, 90-second run, before vs after:

| | before | after |
|---|---|---|
| total leaked | 55.2 M | 9.5 M |
| `render() → anythingFullscreen() → XQueryTree` leaked | 5.85 M + 5.85 M | **gone** |

After the fix, no leaked allocation stack passes through `render()` at all — the remaining ~9.5 M is one-time setup (textures, GL context) that stays flat for the process lifetime. Live instances now hold ~200 MB steady instead of climbing to 8 GB.
