### PR TITLE
fix(album-art): avoid GL 4.5 glGetnTexImage in the 3.3 context (NULL ptr crash on album art)

### DIFF
--- a/src/WallpaperEngine/Render/AlbumTexture.cpp
+++ b/src/WallpaperEngine/Render/AlbumTexture.cpp
@@ -71,11 +71,28 @@ void AlbumTexture::copyContents (const TextureProvider& other) const noexcept {
     // RGBA8 texture: 4 bytes per pixel
     size_t bufferSize = other.getTextureWidth (0) * other.getTextureHeight (0) * 4;
 
-    uint8_t* buffer = new uint8_t[bufferSize];
+    uint8_t* buffer = new uint8_t[bufferSize] ();
 
-    // Read the source texture
-    glBindTexture (GL_TEXTURE_2D, other.getTextureID (0));
-    glGetnTexImage (GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, bufferSize, buffer);
+    // Read the source texture back through a temporary FBO. glReadPixels is GL 1.0
+    // and works in this engine's 3.3 core context; glGetnTexImage is GL 4.5, so GLEW
+    // leaves its pointer NULL under a 3.3 context and calling it segfaults (jump to
+    // 0x0) — hit the moment MPRIS album art arrives (e.g. a browser video starts).
+    GLint previousFBO = 0;
+    glGetIntegerv (GL_FRAMEBUFFER_BINDING, &previousFBO);
+
+    GLuint readFBO = 0;
+    glGenFramebuffers (1, &readFBO);
+    glBindFramebuffer (GL_FRAMEBUFFER, readFBO);
+    glFramebufferTexture2D (GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, other.getTextureID (0), 0);
+
+    if (glCheckFramebufferStatus (GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
+        glReadPixels (
+            0, 0, other.getTextureWidth (0), other.getTextureHeight (0), GL_RGBA, GL_UNSIGNED_BYTE, buffer
+        );
+    }
+
+    glBindFramebuffer (GL_FRAMEBUFFER, previousFBO);
+    glDeleteFramebuffers (1, &readFBO);
 
     // Upload into another texture
     glBindTexture (GL_TEXTURE_2D, this->m_textureID);


### PR DESCRIPTION
## Problem

`AlbumTexture::copyContents()` reads the source texture back with **`glGetnTexImage`**, which is **GL 4.5** (`GL_ARB_robustness`). But the engine creates a **GL 3.3 core** context (`GLFWOpenGLDriver` requests 3.3, `GLFW_OPENGL_CORE_PROFILE`), so GLEW leaves `glGetnTexImage`'s function pointer **NULL**, and calling it jumps to `0x0` → **SIGSEGV**.

It triggers the moment a media source publishes album art — e.g. a browser tab starts a video and its MPRIS player emits `Metadata` with `mpris:artUrl`. On a tiled desktop (video in one pane) it crashes the wallpaper on every new video; under a service manager it just respawns, looking like a constant relaunch.

Backtrace:
```
#0  0x0000000000000000 in ??? ()
#1  AlbumTexture::copyContents(TextureProvider const&) const
#2  TextureCache::TextureCache(...)::{lambda(MediaInfo const&)#1}
#3  MediaSource::fireAlbumArtListeners()
#4  DBusMediaSource::parseMetadata(DBusMessageIter&)
#5  dbus_message_filter(...)
#6  dbus_connection_dispatch()
#7  DBusMediaSource::update()
#8  WallpaperApplication::render()
```

## Fix

Read the source texture back through a temporary FBO with **`glReadPixels`** (GL 1.0, always present in a 3.3 context) instead of `glGetnTexImage`, then upload as before. This mirrors what the rest of the codebase already does — `glReadPixels` is used for texture readback in `WallpaperApplication`/`GLFWOpenGLDriver`, and genuine 4.5 paths are guarded with `GLEW_VERSION_4_5`. The readback buffer is now zero-initialized so an incomplete FBO uploads black rather than uninitialized memory.

No behavior change on GL 4.5+ systems; fixes a hard crash on the 3.3 context the engine actually requests.

Verified on an RTX 3060 Ti / X11 desktop: previously crashed on every browser video start; after the fix, album art copies fine and no crash.
