### PR TITLE
fix: guard null PulseAudio operations in playing detector

### DIFF
--- a/src/WallpaperEngine/Audio/Drivers/Detectors/PulseAudioPlayingDetector.cpp
+++ b/src/WallpaperEngine/Audio/Drivers/Detectors/PulseAudioPlayingDetector.cpp
@@ -30,7 +30,9 @@ void defaultSinkInfoCallback (pa_context* context, const pa_server_info* info, v
 
     pa_operation* op = pa_context_get_sink_input_info_list (context, sinkInputInfoCallback, userdata);
 
-    pa_operation_unref (op);
+    if (op != nullptr) {
+	pa_operation_unref (op);
+    }
 }
 
 PulseAudioPlayingDetector::PulseAudioPlayingDetector (
@@ -73,6 +75,10 @@ void PulseAudioPlayingDetector::update () {
 
     // start discovery of sinks
     pa_operation* op = pa_context_get_server_info (this->m_context, defaultSinkInfoCallback, this);
+
+    if (op == nullptr) {
+	return;
+    }
 
     // wait until all the operations are done
     while (pa_operation_get_state (op) == PA_OPERATION_RUNNING) {


### PR DESCRIPTION
## Summary

- Guard a null operation returned by `pa_context_get_server_info()` before polling its state.
- Guard a null operation returned by `pa_context_get_sink_input_info_list()` before unreferencing it.
- Keep auto-mute detection fail-open for the current update when PulseAudio cannot create an introspection operation.

## Why

PulseAudio introspection calls can fail to create an operation when the context is no longer ready. `PulseAudioPlayingDetector` currently passes those null pointers to APIs that assert on null, aborting the whole wallpaper renderer.

The two failure paths produce:

```text
Assertion 'o' failed at ../src/pulse/operation.c:136, function pa_operation_get_state(). Aborting.
Assertion 'o' failed at ../src/pulse/operation.c:67, function pa_operation_unref(). Aborting.
```

This follows the null-guard pattern already used for PulseAudio operations in the recorder after #566.

## Reproduction and verification

I used `LD_PRELOAD` shims to make each PulseAudio introspection function return null at the real renderer call site, while running a 1x1 X11 renderer outside the visible desktop.

Before this change:

- null server-info operation: assertion abort, exit 134
- null sink-input-list operation: assertion abort, exit 134

After this change, both injected-failure runs continued rendering for six seconds and exited only when the test timeout sent SIGTERM (exit 124). A normal renderer run also remained healthy.

Additional checks:

- full `cmake --build build --parallel 2` completed successfully
- `git diff --check` passed

## Scope

This PR only fixes null operation handling during detector updates. It does not address the separate constructor wait/deadlock reported in #649.
