### PR TITLE
fix(text): correct text object size and vertical position (#583)

### DIFF
--- a/src/WallpaperEngine/Render/Objects/CText.cpp
+++ b/src/WallpaperEngine/Render/Objects/CText.cpp
@@ -456,17 +456,19 @@ void CText::render () {
     const glm::vec3 scale = m_text.scale->value->getVec3 ();
     const glm::vec3 origin = m_text.origin->value->getVec3 ();
 
-    // WE uses a Y-down coordinate system (origin at top-left, y increases downward).
-    // The final FBO is presented to screen with vflip=true on Wayland/GLFW, which maps
-    // GL y- to screen top and GL y+ to screen bottom. This effectively inverts Y again,
-    // so we need: gl_y = origin.y - scene_h/2  (not the CImage-style scene_h/2 - origin.y).
-    // CImage pre-compensates for X11 (no vflip) and gets corrected by the Wayland vflip.
-    // CText renders with direct vflip-aware coordinates.
+    // WE uses a Y-down coordinate system (origin at top-left, y increases downward),
+    // so scene y maps to GL y as scene_h/2 - origin.y, matching CImage.
+    //
+    // This previously used origin.y - scene_h/2 on the reasoning that the Wayland/GLFW
+    // vflip inverts Y a second time. Observed behaviour on KWin/Wayland contradicts
+    // that: it mirrors text objects about the scene's horizontal centre line, which
+    // inverts the vertical order of a stacked group. Wallpapers that place a day name
+    // above a date and clock rendered them bottom-up. See #583.
     const float scene_w = getScene ().getCamera ().getWidth ();
     const float scene_h = getScene ().getCamera ().getHeight ();
     const glm::vec3 gl_origin = {
 	origin.x - scene_w * 0.5f,
-	origin.y - scene_h * 0.5f,
+	scene_h * 0.5f - origin.y,
 	origin.z,
     };
 

--- a/src/WallpaperEngine/Render/Objects/CText.cpp
+++ b/src/WallpaperEngine/Render/Objects/CText.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <vector>
 #include <cstdlib>
+#include <cmath>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -224,8 +225,12 @@ float CText::pixelsPerPoint () const {
                 static_cast<float> (m_ftFace->size->metrics.height) / 64.0f;
 
             if (referenceLineHeight > 0.0f) {
-                m_pixelsPerPoint =
+                const float derived =
                     (boxLineHeight * static_cast<float> (REFERENCE_PX) / referenceLineHeight) / pointSize;
+
+                if (std::isfinite (derived) && derived > 0.0f) {
+                    m_pixelsPerPoint = derived;
+                }
             }
         }
 
@@ -242,8 +247,11 @@ float CText::pixelsPerPoint () const {
         m_pixelsPerPoint = 4.15f;
 
         if (const char* env = std::getenv ("WPE_TEXT_SCALE")) {
+            // strtof yields inf for "inf" and for overflowing input such as "1e999",
+            // both of which would survive a bare > 0 test and poison the conversion
+            // to unsigned int further down.
             const float parsed = std::strtof (env, nullptr);
-            if (parsed > 0.0f) {
+            if (std::isfinite (parsed) && parsed > 0.0f) {
                 m_pixelsPerPoint = parsed;
             }
         }
@@ -257,8 +265,17 @@ unsigned int CText::computeEffectivePixelSize () const {
     // model matrix by scale again; the two cancelled, pinning every text object to
     // pointSize scene units regardless of its declared scale. Deriving the rasterisation
     // size from the scene's pixels-per-point instead lets the per-object scale through.
-    return std::max<unsigned int> (
-        1u, static_cast<unsigned int> (m_text.pointSize->value->getFloat () * pixelsPerPoint ()));
+    const float pixels = m_text.pointSize->value->getFloat () * pixelsPerPoint ();
+
+    if (!std::isfinite (pixels) || pixels <= 1.0f) {
+        return 1u;
+    }
+
+    // Cap before converting: a malformed scene or a wild WPE_TEXT_SCALE must not
+    // overflow the cast or ask FreeType for an unreasonable glyph atlas.
+    constexpr float MAX_PIXEL_SIZE = 2048.0f;
+
+    return static_cast<unsigned int> (std::min (pixels, MAX_PIXEL_SIZE));
 }
 
 void CText::initScriptLayer () {

--- a/src/WallpaperEngine/Render/Objects/CText.cpp
+++ b/src/WallpaperEngine/Render/Objects/CText.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <vector>
+#include <cstdlib>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -201,15 +202,63 @@ bool CText::loadSystemFont () {
     return true;
 }
 
+float CText::pixelsPerPoint () const {
+    if (m_pixelsPerPoint > 0.0f) {
+        return m_pixelsPerPoint;
+    }
+
+    // WE stores the authored extent of the text block in `size`. Its height is the
+    // glyph line height plus `padding` on each edge, at whatever pixel size WE
+    // rasterised at. Recovering that pixel size and dividing by the authored point
+    // size yields the scene's pixels-per-point with no magic constant. Line height
+    // scales linearly with pixel size, so a single reference measurement inverts it.
+    const float boxLineHeight = m_text.size.y - 2.0f * static_cast<float> (m_text.padding);
+    const float pointSize = m_text.pointSize->value->getFloat ();
+
+    if (m_ftFace != nullptr && boxLineHeight > 0.0f && pointSize > 0.0f) {
+        constexpr FT_UInt REFERENCE_PX = 100;
+        const FT_UInt previous = static_cast<FT_UInt> (m_lastPixelSize);
+
+        if (FT_Set_Pixel_Sizes (m_ftFace, 0, REFERENCE_PX) == 0) {
+            const float referenceLineHeight =
+                static_cast<float> (m_ftFace->size->metrics.height) / 64.0f;
+
+            if (referenceLineHeight > 0.0f) {
+                m_pixelsPerPoint =
+                    (boxLineHeight * static_cast<float> (REFERENCE_PX) / referenceLineHeight) / pointSize;
+            }
+        }
+
+        // render() only calls FT_Set_Pixel_Sizes when the computed size changes, so
+        // the probe above must not be left as the face's active size.
+        if (previous > 0) {
+            FT_Set_Pixel_Sizes (m_ftFace, 0, previous);
+        }
+    }
+
+    if (m_pixelsPerPoint <= 0.0f) {
+        // Scenes that omit `size` fall back to a value measured across the wallpapers
+        // in #583; WPE_TEXT_SCALE overrides it for testing against other content.
+        m_pixelsPerPoint = 4.15f;
+
+        if (const char* env = std::getenv ("WPE_TEXT_SCALE")) {
+            const float parsed = std::strtof (env, nullptr);
+            if (parsed > 0.0f) {
+                m_pixelsPerPoint = parsed;
+            }
+        }
+    }
+
+    return m_pixelsPerPoint;
+}
+
 unsigned int CText::computeEffectivePixelSize () const {
-    // WE text objects often come with scale ~0.09 that, combined with a modest
-    // pointsize, would rasterize glyphs to ~2px on screen (invisible). Rasterize
-    // at higher resolution so that after the model scale is applied in render()
-    // the on-screen size matches the intended pointsize.
-    const glm::vec3 initialScale = m_text.scale->value->getVec3 ();
-    const float avgScale = (initialScale.x + initialScale.y) * 0.5f;
-    const float compensate = (avgScale > 0.0f && avgScale < 1.0f) ? std::min (1.0f / avgScale, 32.0f) : 1.0f;
-    return std::max<unsigned int> (1u, static_cast<unsigned int> (m_text.pointSize->value->getFloat () * compensate));
+    // Previously this rasterised at pointSize * (1/scale) while render() multiplied the
+    // model matrix by scale again; the two cancelled, pinning every text object to
+    // pointSize scene units regardless of its declared scale. Deriving the rasterisation
+    // size from the scene's pixels-per-point instead lets the per-object scale through.
+    return std::max<unsigned int> (
+        1u, static_cast<unsigned int> (m_text.pointSize->value->getFloat () * pixelsPerPoint ()));
 }
 
 void CText::initScriptLayer () {

--- a/src/WallpaperEngine/Render/Objects/CText.h
+++ b/src/WallpaperEngine/Render/Objects/CText.h
@@ -58,11 +58,14 @@ private:
     bool loadEmbeddedFont ();
     bool loadSystemFont ();
     unsigned int computeEffectivePixelSize () const;
+    float pixelsPerPoint () const;
     void initScriptLayer ();
 
     const Text& m_text;
     std::string m_lastRenderedText;
     unsigned int m_lastPixelSize = 0;
+    /** Scene pixels per point, derived once from the authored size box (see #583) */
+    mutable float m_pixelsPerPoint = 0.0f;
     Scripting::ScriptLayerHandle m_layerHandle = Scripting::kInvalidLayerHandle;
 
     FT_Library m_ftLibrary = nullptr;


### PR DESCRIPTION
Fixes #583. Two separate problems, one commit each.

**Size.** `computeEffectivePixelSize()` rasterises at `pointSize * (1/scale)`, then `render()` scales the model matrix by `scale` again. They cancel, so every text object ends up at exactly `pointSize` scene units no matter what scale it declares — about 18px on my display against a 3840x2160 projection. It also means a day/date/clock group all draw at one size on top of itself.

Rather than swap in another constant, this derives the size from the object's own `size` box. That box's height turns out to be the glyph line height plus `padding` on each edge, at whatever pixel size WE rasterised at — so recovering it and dividing by the authored point size gives the scene's pixels-per-point. On the wallpaper in #583 that lands at 132/132/133px across three objects and two different fonts, which is consistent enough that I don't think it's a coincidence. `pointSize` stays live so the configurable point size from #572 still works, and scenes without a `size` box fall back to the measured ratio.

**Position.** `render()` maps scene Y as `origin.y - scene_h/2`. On KWin/Wayland that mirrors text about the centre line and flips the vertical order of stacked labels — my test wallpaper drew its day/date/clock bottom-up. `scene_h/2 - origin.y`, same as CImage, fixes it.

That second one is Wayland-only tested, I have no X11 box, and the comment I'm replacing claims the old mapping was deliberate. Worth someone checking X11 before it lands. The first commit doesn't depend on it.

Tested on Plasma 6.7.4, KWin Wayland, Mesa/Intel, workshop item 3339082757.
