### PR TITLE
feat(render): embedded host rendering, enabling a Plasma wallpaper plugin (#370)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,8 @@ set(COMMON_SOURCES
     src/WallpaperEngine/Input/MouseInput.h
     src/WallpaperEngine/Input/Drivers/GLFWMouseInput.cpp
     src/WallpaperEngine/Input/Drivers/GLFWMouseInput.h
+    src/WallpaperEngine/Input/Drivers/EmbeddedMouseInput.cpp
+    src/WallpaperEngine/Input/Drivers/EmbeddedMouseInput.h
 
     src/WallpaperEngine/Media/MediaSource.h
     src/WallpaperEngine/Media/MediaSource.cpp
@@ -397,6 +399,13 @@ set(COMMON_SOURCES
     src/WallpaperEngine/Render/Drivers/Output/OutputViewport.cpp
     src/WallpaperEngine/Render/Drivers/Output/OutputViewport.h
     src/WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.h
+    src/WallpaperEngine/Render/Drivers/EmbeddedHost.h
+    src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.cpp
+    src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.h
+    src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutput.cpp
+    src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutput.h
+    src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutputViewport.cpp
+    src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutputViewport.h
     src/WallpaperEngine/Render/Drivers/GLFWOpenGLDriver.cpp
     src/WallpaperEngine/Render/Drivers/VideoDriver.h
     src/WallpaperEngine/Render/Drivers/VideoDriver.cpp

--- a/src/WallpaperEngine/Application/ApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/ApplicationContext.cpp
@@ -463,6 +463,14 @@ void ApplicationContext::loadSettingsFromArgv () {
 	})
 	.append ();
 
+    backgroundGroup.add_argument ("--embedded")
+	.help (
+	    "Render into a framebuffer owned by an embedding host instead of creating a window. "
+	    "Only useful when the renderer is driven as a library, e.g. from the Plasma wallpaper plugin."
+	)
+	.flag ()
+	.action ([this] (const std::string& value) -> void { this->settings.render.mode = EMBEDDED_HOST; });
+
     backgroundGroup.add_argument ("--layer")
 	.help (
 	    "Wayland-only: which wlr-layer-shell layer to anchor the wallpaper to "

--- a/src/WallpaperEngine/Application/ApplicationContext.h
+++ b/src/WallpaperEngine/Application/ApplicationContext.h
@@ -38,6 +38,8 @@ public:
 	DESKTOP_BACKGROUND = 1,
 	/** Explicit window mode with specified geometry */
 	EXPLICIT_WINDOW = 2,
+	/** Rendering into a framebuffer owned by an embedding host */
+	EMBEDDED_HOST = 3,
     };
 
     /**

--- a/src/WallpaperEngine/Application/WallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/WallpaperApplication.cpp
@@ -180,8 +180,13 @@ AssetLocatorUniquePtr WallpaperApplication::setupAssetLocator (const std::string
 }
 
 void WallpaperApplication::loadBackgrounds () {
+    // EMBEDDED_HOST belongs with the windowed modes: it renders a single viewport
+    // named "default" and has no --screen-root to key backgrounds off, so the
+    // per-screen path below would leave m_backgrounds empty, create no wallpapers,
+    // and render nothing at all.
     if (this->m_context.settings.render.mode == ApplicationContext::NORMAL_WINDOW
-	|| this->m_context.settings.render.mode == ApplicationContext::EXPLICIT_WINDOW) {
+	|| this->m_context.settings.render.mode == ApplicationContext::EXPLICIT_WINDOW
+	|| this->m_context.settings.render.mode == ApplicationContext::EMBEDDED_HOST) {
 	auto path = this->m_context.settings.general.defaultBackground;
 
 	if (this->m_context.settings.general.defaultPlaylist.has_value ()

--- a/src/WallpaperEngine/Application/WallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/WallpaperApplication.cpp
@@ -999,6 +999,15 @@ const WallpaperEngine::Render::Drivers::Output::Output& WallpaperApplication::ge
 
 void WallpaperApplication::setDestinationFramebuffer (GLuint framebuffer) {
     this->m_destinationFramebuffer = framebuffer;
+
+    // Reachable before setup() has built the render context - an embedding host
+    // learns its framebuffer as soon as the video driver is constructed, which
+    // happens inside setupOutput(). Record the value and let the wallpapers pick
+    // it up when the caller sets it again after setup() returns.
+    if (this->m_renderContext == nullptr) {
+	return;
+    }
+
     // Update all wallpapers with the new destination framebuffer
     for (const auto& [screen, wallpaper] : this->m_renderContext->getWallpapers ()) {
 	wallpaper->setDestinationFramebuffer (framebuffer);

--- a/src/WallpaperEngine/Application/WallpaperApplication.cpp
+++ b/src/WallpaperEngine/Application/WallpaperApplication.cpp
@@ -856,8 +856,15 @@ void WallpaperApplication::render () {
     static time_t seconds;
     static struct tm* timeinfo;
 
+    // An embedding host owns the frame clock and calls us from its own render
+    // thread. Blocking or self-pausing there stalls the host's rendering, so
+    // both are left to the host in this mode.
+    const bool embedded = this->m_context.settings.render.mode == ApplicationContext::EMBEDDED_HOST;
+
     if (this->m_isPaused) {
-	usleep (FULLSCREEN_CHECK_WAIT_TIME);
+	if (!embedded) {
+	    usleep (FULLSCREEN_CHECK_WAIT_TIME);
+	}
 	if (this->m_fullScreenDetector->anythingFullscreen () && this->m_context.state.general.keepRunning) {
 	    return;
 	}
@@ -928,7 +935,8 @@ void WallpaperApplication::render () {
 	}
 #endif /* DEMOMODE */
 	// check for fullscreen windows and wait until there's none fullscreen
-	if (this->m_fullScreenDetector->anythingFullscreen () && this->m_context.state.general.keepRunning) {
+	if (!embedded && this->m_fullScreenDetector->anythingFullscreen ()
+	    && this->m_context.state.general.keepRunning) {
 	    this->m_isPaused = true;
 	    this->m_pauseStart = std::chrono::steady_clock::now ();
 

--- a/src/WallpaperEngine/Input/Drivers/EmbeddedMouseInput.cpp
+++ b/src/WallpaperEngine/Input/Drivers/EmbeddedMouseInput.cpp
@@ -1,0 +1,26 @@
+#include "EmbeddedMouseInput.h"
+#include "WallpaperEngine/Render/Drivers/EmbeddedHost.h"
+
+using namespace WallpaperEngine::Input::Drivers;
+
+EmbeddedMouseInput::EmbeddedMouseInput (const Render::Drivers::EmbeddedHost& host) : m_host (host) { }
+
+void EmbeddedMouseInput::update () {
+    const glm::dvec2 pointer = this->m_host.getPointerPosition ();
+
+    // A negative position means the pointer is not over the wallpaper. Hold the
+    // last known value instead of snapping to the origin, which would otherwise
+    // yank parallax to a corner every time the cursor leaves the desktop.
+    if (pointer.x < 0 || pointer.y < 0) {
+	return;
+    }
+
+    // Host reports top-left origin, the engine works bottom-left.
+    this->m_position = {pointer.x, static_cast<double> (this->m_host.getFramebufferSize ().y) - pointer.y};
+}
+
+glm::dvec2 EmbeddedMouseInput::position () const { return this->m_position; }
+
+WallpaperEngine::Input::MouseClickStatus EmbeddedMouseInput::leftClick () const { return Released; }
+
+WallpaperEngine::Input::MouseClickStatus EmbeddedMouseInput::rightClick () const { return Released; }

--- a/src/WallpaperEngine/Input/Drivers/EmbeddedMouseInput.h
+++ b/src/WallpaperEngine/Input/Drivers/EmbeddedMouseInput.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "WallpaperEngine/Input/MouseInput.h"
+
+namespace WallpaperEngine::Render::Drivers {
+class EmbeddedHost;
+}
+
+namespace WallpaperEngine::Input::Drivers {
+/**
+ * Mouse input backed by the embedding host.
+ *
+ * The host reports the pointer with a top-left origin, matching the window
+ * systems the other drivers deal with; update() converts it to the engine's
+ * bottom-left convention. Clicks are always reported as released: a wallpaper
+ * sits behind the desktop and must never consume button presses.
+ */
+class EmbeddedMouseInput final : public MouseInput {
+public:
+    explicit EmbeddedMouseInput (const Render::Drivers::EmbeddedHost& host);
+
+    void update () override;
+    [[nodiscard]] glm::dvec2 position () const override;
+    [[nodiscard]] MouseClickStatus leftClick () const override;
+    [[nodiscard]] MouseClickStatus rightClick () const override;
+
+private:
+    const Render::Drivers::EmbeddedHost& m_host;
+    glm::dvec2 m_position = {0, 0};
+};
+} // namespace WallpaperEngine::Input::Drivers

--- a/src/WallpaperEngine/Render/Drivers/EmbeddedHost.h
+++ b/src/WallpaperEngine/Render/Drivers/EmbeddedHost.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <glm/vec2.hpp>
+
+namespace WallpaperEngine::Render::Drivers {
+/**
+ * Interface implemented by a host application that embeds the renderer inside
+ * its own OpenGL context (for example a Qt Quick item inside plasmashell).
+ *
+ * The host owns the context, the surface and the frame clock; the renderer only
+ * ever draws into the framebuffer the host hands it. Keeping this as a pure
+ * interface means the library never has to link against the host's toolkit.
+ */
+class EmbeddedHost {
+public:
+    virtual ~EmbeddedHost () = default;
+
+    /**
+     * Resolves an OpenGL entrypoint using the host's context. GLEW is
+     * initialized from this, so it must be valid before the driver is built.
+     */
+    [[nodiscard]] virtual void* getProcAddress (const char* name) const = 0;
+
+    /**
+     * @return The framebuffer the renderer must draw the final image into.
+     *         This changes whenever the host resizes, so it is queried per frame.
+     */
+    [[nodiscard]] virtual unsigned int getDestinationFramebuffer () const = 0;
+
+    /**
+     * @return Size in physical pixels of the destination framebuffer.
+     */
+    [[nodiscard]] virtual glm::ivec2 getFramebufferSize () const = 0;
+
+    /**
+     * @return Seconds elapsed since the host started rendering. The renderer
+     *         uses this to drive animations, so it must be monotonic.
+     */
+    [[nodiscard]] virtual float getRenderTime () const = 0;
+
+    /**
+     * @return Pointer position in physical pixels with a top-left origin, or a
+     *         negative position when the pointer is not over the wallpaper.
+     *         The driver converts this to the engine's bottom-left origin.
+     */
+    [[nodiscard]] virtual glm::dvec2 getPointerPosition () const = 0;
+
+    /**
+     * Whether the final blit has to be flipped vertically. Hosts that treat the
+     * destination as a plain GL framebuffer want false; hosts that present it as
+     * a top-left-origin texture want true.
+     */
+    [[nodiscard]] virtual bool wantsVerticalFlip () const = 0;
+};
+} // namespace WallpaperEngine::Render::Drivers

--- a/src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.cpp
+++ b/src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.cpp
@@ -1,0 +1,77 @@
+#include "EmbeddedOpenGLDriver.h"
+#include "WallpaperEngine/Logging/Log.h"
+#include "WallpaperEngine/Render/Drivers/Output/EmbeddedOutput.h"
+
+#include <GL/glew.h>
+
+using namespace WallpaperEngine::Render::Drivers;
+
+EmbeddedOpenGLDriver::EmbeddedOpenGLDriver (
+    ApplicationContext& context, WallpaperApplication& app, EmbeddedHost& host
+) :
+    VideoDriver (app, m_mouseInput), m_context (context), m_host (host), m_mouseInput (host) {
+    // The host's context has to be current already: everything below touches GL.
+    glewExperimental = GL_TRUE;
+
+    if (const GLenum result = glewInit (); result != GLEW_OK) {
+	// Non-fatal for the same reason the Wayland driver tolerates it: GLEW
+	// reports a missing GLX display on EGL-only setups even though every
+	// entrypoint it resolved is perfectly usable.
+	sLog.error (
+	    "Failed to initialize GLEW, but continuing with the host context: ",
+	    reinterpret_cast<const char*> (glewGetErrorString (result))
+	);
+    }
+
+    this->m_output = new Output::EmbeddedOutput (context, *this, host);
+
+    // Point the renderer at the host's framebuffer before any wallpaper is
+    // built, so the first frame already lands in the right place.
+    app.setDestinationFramebuffer (host.getDestinationFramebuffer ());
+}
+
+EmbeddedOpenGLDriver::~EmbeddedOpenGLDriver () { delete this->m_output; }
+
+Output::Output& EmbeddedOpenGLDriver::getOutput () { return *this->m_output; }
+
+float EmbeddedOpenGLDriver::getRenderTime () const { return this->m_host.getRenderTime (); }
+
+bool EmbeddedOpenGLDriver::closeRequested () {
+    // The host decides our lifetime; we never ask to be torn down.
+    return false;
+}
+
+void EmbeddedOpenGLDriver::resizeWindow (glm::ivec2 size) {
+    // Sizing belongs to the host. updateRender() picks the new size up.
+}
+
+void EmbeddedOpenGLDriver::resizeWindow (glm::ivec4 sizeandpos) {
+    // See above.
+}
+
+void EmbeddedOpenGLDriver::showWindow () { }
+
+void EmbeddedOpenGLDriver::hideWindow () { }
+
+glm::ivec2 EmbeddedOpenGLDriver::getFramebufferSize () const { return this->m_host.getFramebufferSize (); }
+
+uint32_t EmbeddedOpenGLDriver::getFrameCounter () const { return this->m_frameCounter; }
+
+void* EmbeddedOpenGLDriver::getProcAddress (const char* name) const { return this->m_host.getProcAddress (name); }
+
+void EmbeddedOpenGLDriver::dispatchEventQueue () {
+    // Qt hands out a fresh FBO whenever the item is resized or its scene graph
+    // node is rebuilt, so re-point the wallpapers every frame rather than
+    // trusting the handle captured at construction time.
+    this->getApp ().setDestinationFramebuffer (this->m_host.getDestinationFramebuffer ());
+
+    this->m_output->updateRender ();
+
+    for (const auto& viewport : this->m_output->getViewports () | std::views::values) {
+	this->getApp ().update (viewport);
+    }
+
+    // No buffer swap and no FPS limiter: the host presents the framebuffer and
+    // owns the frame clock, so throttling here would just fight with it.
+    this->m_frameCounter++;
+}

--- a/src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.cpp
+++ b/src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.cpp
@@ -25,9 +25,10 @@ EmbeddedOpenGLDriver::EmbeddedOpenGLDriver (
 
     this->m_output = new Output::EmbeddedOutput (context, *this, host);
 
-    // Point the renderer at the host's framebuffer before any wallpaper is
-    // built, so the first frame already lands in the right place.
-    app.setDestinationFramebuffer (host.getDestinationFramebuffer ());
+    // The host's framebuffer is deliberately not published here. This runs from
+    // inside WallpaperApplication::setup(), before the render context exists, so
+    // there is nothing to propagate to yet. The host sets it once setup() has
+    // returned, and again whenever its framebuffer is recreated.
 }
 
 EmbeddedOpenGLDriver::~EmbeddedOpenGLDriver () { delete this->m_output; }

--- a/src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.h
+++ b/src/WallpaperEngine/Render/Drivers/EmbeddedOpenGLDriver.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "WallpaperEngine/Application/ApplicationContext.h"
+#include "WallpaperEngine/Application/WallpaperApplication.h"
+#include "WallpaperEngine/Input/Drivers/EmbeddedMouseInput.h"
+#include "WallpaperEngine/Render/Drivers/EmbeddedHost.h"
+#include "WallpaperEngine/Render/Drivers/VideoDriver.h"
+
+namespace WallpaperEngine::Application {
+class ApplicationContext;
+class WallpaperApplication;
+} // namespace WallpaperEngine::Application
+
+namespace WallpaperEngine::Render::Drivers {
+using namespace WallpaperEngine::Application;
+
+/**
+ * Video driver for running the renderer inside a host that already owns an
+ * OpenGL context, such as a Qt Quick item living in plasmashell.
+ *
+ * Unlike every other driver this one creates no window, no context and no event
+ * loop. The host drives the frame clock by calling dispatchEventQueue() with its
+ * context current, and the renderer draws straight into the host's framebuffer.
+ */
+class EmbeddedOpenGLDriver final : public VideoDriver {
+public:
+    EmbeddedOpenGLDriver (ApplicationContext& context, WallpaperApplication& app, EmbeddedHost& host);
+    ~EmbeddedOpenGLDriver () override;
+
+    [[nodiscard]] Output::Output& getOutput () override;
+    [[nodiscard]] float getRenderTime () const override;
+    bool closeRequested () override;
+    void resizeWindow (glm::ivec2 size) override;
+    void resizeWindow (glm::ivec4 sizeandpos) override;
+    void showWindow () override;
+    void hideWindow () override;
+    [[nodiscard]] glm::ivec2 getFramebufferSize () const override;
+    [[nodiscard]] uint32_t getFrameCounter () const override;
+    void dispatchEventQueue () override;
+    [[nodiscard]] void* getProcAddress (const char* name) const override;
+
+private:
+    ApplicationContext& m_context;
+    EmbeddedHost& m_host;
+    Input::Drivers::EmbeddedMouseInput m_mouseInput;
+    Output::Output* m_output = nullptr;
+    uint32_t m_frameCounter = 0;
+};
+} // namespace WallpaperEngine::Render::Drivers

--- a/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutput.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutput.cpp
@@ -1,0 +1,39 @@
+#include "EmbeddedOutput.h"
+#include "EmbeddedOutputViewport.h"
+#include "WallpaperEngine/Render/Drivers/EmbeddedHost.h"
+
+using namespace WallpaperEngine::Render::Drivers::Output;
+
+EmbeddedOutput::EmbeddedOutput (ApplicationContext& context, VideoDriver& driver, const EmbeddedHost& host) :
+    Output (context, driver), m_host (host) {
+    const glm::ivec2 size = this->m_host.getFramebufferSize ();
+
+    this->m_fullWidth = size.x;
+    this->m_fullHeight = size.y;
+
+    this->m_viewports ["default"]
+	= new EmbeddedOutputViewport { { 0, 0, this->m_fullWidth, this->m_fullHeight }, "default" };
+}
+
+void EmbeddedOutput::reset () { }
+
+bool EmbeddedOutput::renderVFlip () const { return this->m_host.wantsVerticalFlip (); }
+
+bool EmbeddedOutput::renderMultiple () const { return false; }
+
+bool EmbeddedOutput::haveImageBuffer () const { return false; }
+
+void* EmbeddedOutput::getImageBuffer () const { return nullptr; }
+
+uint32_t EmbeddedOutput::getImageBufferSize () const { return 0; }
+
+void EmbeddedOutput::updateRender () const {
+    // The host is free to resize us at any point, so re-read the size every
+    // frame and re-stretch the viewport instead of cropping the old render.
+    const glm::ivec2 size = this->m_host.getFramebufferSize ();
+
+    this->m_fullWidth = size.x;
+    this->m_fullHeight = size.y;
+
+    this->m_viewports.at ("default")->viewport = { 0, 0, this->m_fullWidth, this->m_fullHeight };
+}

--- a/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutput.h
+++ b/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutput.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Output.h"
+#include "WallpaperEngine/Render/Drivers/VideoDriver.h"
+
+namespace WallpaperEngine::Render::Drivers {
+class EmbeddedHost;
+}
+
+namespace WallpaperEngine::Render::Drivers::Output {
+/**
+ * Output that targets the framebuffer owned by an embedding host.
+ *
+ * There is exactly one viewport covering the whole framebuffer: the host
+ * instantiates one wallpaper per screen, so screen splitting is the host's job
+ * rather than ours.
+ */
+class EmbeddedOutput final : public Output {
+public:
+    EmbeddedOutput (ApplicationContext& context, VideoDriver& driver, const EmbeddedHost& host);
+
+    void reset () override;
+    bool renderVFlip () const override;
+    bool renderMultiple () const override;
+    bool haveImageBuffer () const override;
+    void* getImageBuffer () const override;
+    uint32_t getImageBufferSize () const override;
+    void updateRender () const override;
+
+private:
+    const EmbeddedHost& m_host;
+};
+} // namespace WallpaperEngine::Render::Drivers::Output

--- a/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutputViewport.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutputViewport.cpp
@@ -1,0 +1,12 @@
+#include "EmbeddedOutputViewport.h"
+
+#include <utility>
+
+using namespace WallpaperEngine::Render::Drivers::Output;
+
+EmbeddedOutputViewport::EmbeddedOutputViewport (glm::ivec4 viewport, std::string name) :
+    OutputViewport (viewport, std::move (name)) { }
+
+void EmbeddedOutputViewport::makeCurrent () { }
+
+void EmbeddedOutputViewport::swapOutput () { }

--- a/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutputViewport.h
+++ b/src/WallpaperEngine/Render/Drivers/Output/EmbeddedOutputViewport.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "OutputViewport.h"
+
+namespace WallpaperEngine::Render::Drivers::Output {
+/**
+ * Viewport for an embedded host. The host's context is already current when the
+ * renderer runs and the host presents the framebuffer itself, so both hooks are
+ * intentionally empty.
+ */
+class EmbeddedOutputViewport final : public OutputViewport {
+public:
+    EmbeddedOutputViewport (glm::ivec4 viewport, std::string name);
+
+    void makeCurrent () override;
+    void swapOutput () override;
+};
+} // namespace WallpaperEngine::Render::Drivers::Output

--- a/src/WallpaperEngine/Render/Drivers/VideoFactories.cpp
+++ b/src/WallpaperEngine/Render/Drivers/VideoFactories.cpp
@@ -28,7 +28,26 @@ void VideoFactories::registerDriver (
 	map.emplace (xdgSessionType, factory);
 	this->m_driverFactories.emplace (forMode, map);
     } else {
-	cur->second.emplace (xdgSessionType, factory);
+	// insert_or_assign, not emplace: emplace keeps the existing entry, so a
+	// second registration for the same mode and session type was silently
+	// discarded and the first factory stayed live even after its owner died.
+	cur->second.insert_or_assign (xdgSessionType, factory);
+    }
+}
+
+void VideoFactories::unregisterDriver (
+    ApplicationContext::WINDOW_MODE forMode, const std::string& xdgSessionType
+) {
+    const auto cur = this->m_driverFactories.find (forMode);
+
+    if (cur == this->m_driverFactories.end ()) {
+	return;
+    }
+
+    cur->second.erase (xdgSessionType);
+
+    if (cur->second.empty ()) {
+	this->m_driverFactories.erase (cur);
     }
 }
 

--- a/src/WallpaperEngine/Render/Drivers/VideoFactories.h
+++ b/src/WallpaperEngine/Render/Drivers/VideoFactories.h
@@ -32,6 +32,18 @@ public:
     );
 
     /**
+     * Removes a previously registered driver factory.
+     *
+     * Factories may capture state owned by the caller. This instance is a static
+     * that is not destroyed until exit, so a caller that dies first must withdraw
+     * its factory or leave a dangling capture behind.
+     *
+     * @param forMode
+     * @param xdgSessionType
+     */
+    void unregisterDriver (ApplicationContext::WINDOW_MODE forMode, const std::string& xdgSessionType);
+
+    /**
      * Adds a new handler for the given XDG_SESSION_TYPE
      *
      * @param xdgSessionType


### PR DESCRIPTION
Adds a render path for hosts that own their own GL context and framebuffer, so
the renderer can be driven as a library instead of creating a window.

My reason for wanting it is #370. On Plasma the wallpaper's layer surface and
plasmashell's desktop are opaque peers in one KWin layer, so whichever is on top
wins and you get a visible wallpaper or a usable desktop, never both - no
`--layer` value fixes that, because the problem isn't stacking order. Rendering
*inside* plasmashell does fix it, and this is the piece that makes that possible.

**This does not close #370 on its own.** The consumer has to live inside the
shell to be a Plasma wallpaper at all; that part is a separate project. What this
adds is the capability. I have a Plasma 6 plugin running on top of it - scenes
and their text render correctly across three screens with icons and right-click
intact - and I'm happy to link it if that's useful.

### What's here

`EMBEDDED_HOST` window mode plus `--embedded`, and an `EmbeddedOpenGLDriver` that
renders into a caller-supplied framebuffer: no window, no context creation, no
buffer swap, no frame loop. The host implements `EmbeddedHost` (proc address,
destination framebuffer, size, time, pointer) and calls `setup()` and `render()`
when it wants a frame. `EmbeddedHost.h` is deliberately Qt-free so the library
picks up no toolkit dependency.

`WallpaperApplication::render()` no longer sleeps or self-pauses in this mode -
both assume ownership of the loop, and on a host's render thread the sleep stalls
the host.

### Fixes that aren't specific to embedding

- `VideoFactories::registerDriver` used `map::emplace` for the session-type entry,
  which keeps the existing value rather than replacing it. A second registration
  for the same mode and session type was silently discarded and the first factory
  stayed live indefinitely - including after whatever it captured had been
  destroyed. Now `insert_or_assign`, plus an `unregisterDriver` so a factory's
  owner can withdraw it, since `sInstance` lives until `exit()`.
- `setDestinationFramebuffer` dereferenced `m_renderContext` unconditionally, but
  a video driver is constructed inside `setupOutput()`, before `setup()` has built
  that context. It now records the value and returns if there's nothing to
  propagate to yet.
- `loadBackgrounds()` routed the windowed modes to the `"default"` background and
  everything else to the per-screen path keyed off `--screen-root`. A mode that is
  neither loads nothing at all, and the failure is completely silent - no error,
  no exception, just a render loop drawing an empty set of wallpapers. Cost me
  several hours; worth a guard even if embedded mode isn't wanted.

### Relationship to #662

Independent of it. That one is a `CText` fix and touches no file here; this branch
is rebased straight onto `main` so the two can be reviewed or merged in any order.

### Testing

Plasma 6.7.4, KWin Wayland, Mesa/Intel, workshop item 3339082757 (a scene with
clock/date/day text), across three displays. Standalone X11 and Wayland paths are
untouched by the embedded code, but I've only smoke-tested them - the shared
changes above are the ones worth a second look.
