### PR TITLE
Fix #500: Cannot enable `--screen-root` on Wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,7 +564,8 @@ if(BUILD_TESTING)
         src/WallpaperEngine/Testing/Harnesses/RenderHarness.cpp
         src/WallpaperEngine/Testing/Harnesses/RenderHarness.h
         src/WallpaperEngine/Testing/Cases/MouseCoordinates.cpp
-        src/WallpaperEngine/Testing/Cases/PropertyParser.cpp)
+        src/WallpaperEngine/Testing/Cases/PropertyParser.cpp
+        src/WallpaperEngine/Testing/Cases/ApplicationContext.cpp)
 endif()
 
 add_library(

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ If you're one of those developers, feel free to open an issue to get your projec
 | `--screen-root <screen>` | Set as background for specific screen |
 | `--screen-span <screen-1>,<screen-2>,...` | Stretch a single wallpaper across multiple screens |
 | `--bg <id/path>` | Assign a background to a specific screen (use after `--screen-root`/`--screen-span`) |
+| `--layer <layer>` | Wayland layer-shell layer: `background` (default), `bottom`, `top`, or `overlay` |
 | `--scaling <mode>` | Wallpaper scaling: `stretch`, `fit`, `fill`, or `default` |
 | `--clamping <mode>` | Set texture clamping: `clamp`, `border`, `repeat` |
 | `--assets-dir <path>` | Set custom path for assets |
@@ -303,7 +304,7 @@ linux-wallpaperengine --set-property bloom=1 2370927443
 
 ## 🧪 Wayland & X11 Support
 
-- **Wayland**: Works with compositors that support `wlr-layer-shell-unstable`. Uses `xdg-output-unstable-v1` for accurate monitor positioning (required for `--screen-span`).
+- **Wayland**: Works with compositors that support `wlr-layer-shell-unstable`. Desktop backgrounds use the `background` layer by default so desktop icons remain accessible; use `--layer bottom` for compositor compatibility if needed. Uses `xdg-output-unstable-v1` for accurate monitor positioning (required for `--screen-span`).
 - **X11**: Requires XRandr. Use `--screen-root <screen_name>` (as shown in `xrandr`).
 
 > ⚠ For X11 users: Currently doesn't work if a compositor or desktop environment (e.g. GNOME, KDE, Nautilus) is drawing the background.

--- a/src/WallpaperEngine/Application/ApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/ApplicationContext.cpp
@@ -466,12 +466,13 @@ void ApplicationContext::loadSettingsFromArgv () {
     backgroundGroup.add_argument ("--layer")
 	.help (
 	    "Wayland-only: which wlr-layer-shell layer to anchor the wallpaper to "
-	    "(background, bottom, top, overlay). Default: bottom. "
-	    "Use 'background' on niri to pair with the `place-within-backdrop` layer-rule, "
+	    "(background, bottom, top, overlay). Default: background. "
+	    "Use 'bottom' for compositor compatibility if needed. "
+	    "On niri, 'background' pairs with the `place-within-backdrop` layer-rule, "
 	    "otherwise the wallpaper will be cloned to every workspace in the overview."
 	)
 	.choices ("background", "bottom", "top", "overlay")
-	.default_value (std::string ("bottom"))
+	.default_value (std::string ("background"))
 	.action ([this] (const std::string& value) -> void {
 	    if (value == "background") {
 		this->settings.render.wayland.layer = WAYLAND_LAYER_BACKGROUND;

--- a/src/WallpaperEngine/Application/ApplicationContext.h
+++ b/src/WallpaperEngine/Application/ApplicationContext.h
@@ -217,7 +217,7 @@ public:
                 .scalingMode = WallpaperEngine::Render::WallpaperState::TextureUVsScaling::DefaultUVs,
             },
             .wayland = {
-                .layer = WAYLAND_LAYER_BOTTOM,
+                .layer = WAYLAND_LAYER_BACKGROUND,
             },
         },
         .audio = {

--- a/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
+++ b/src/WallpaperEngine/Render/Drivers/Output/WaylandOutputViewport.cpp
@@ -175,8 +175,10 @@ void WaylandOutputViewport::setupLS () {
 	    wlrLayer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
 	    break;
 	case WallpaperEngine::Application::ApplicationContext::WAYLAND_LAYER_BOTTOM:
-	default:
 	    wlrLayer = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+	    break;
+	default:
+	    wlrLayer = ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
 	    break;
     }
 

--- a/src/WallpaperEngine/Testing/Cases/ApplicationContext.cpp
+++ b/src/WallpaperEngine/Testing/Cases/ApplicationContext.cpp
@@ -1,0 +1,41 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <initializer_list>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "WallpaperEngine/Application/ApplicationContext.h"
+
+using WallpaperEngine::Application::ApplicationContext;
+
+namespace {
+template <typename Test>
+void withParsedArguments (std::initializer_list<std::string> arguments, Test&& test) {
+    std::vector<std::string> args (arguments);
+    std::vector<char*> argv;
+    argv.reserve (args.size ());
+    for (auto& argument : args) {
+	argv.push_back (argument.data ());
+    }
+
+    ApplicationContext context (static_cast<int> (argv.size ()), argv.data ());
+    context.loadSettingsFromArgv ();
+    std::forward<Test> (test) (context);
+}
+} // namespace
+
+TEST_CASE ("Wayland background layer defaults to background") {
+    withParsedArguments ({ "linux-wallpaperengine", "--screen-root", "HDMI-A-1", "/tmp/background" },
+	[] (const ApplicationContext& context) {
+	    CHECK (context.settings.render.mode == ApplicationContext::DESKTOP_BACKGROUND);
+	    CHECK (context.settings.render.wayland.layer == ApplicationContext::WAYLAND_LAYER_BACKGROUND);
+	});
+}
+
+TEST_CASE ("Wayland background layer can be overridden with bottom") {
+    withParsedArguments ({ "linux-wallpaperengine", "--layer", "bottom", "--screen-root", "HDMI-A-1", "/tmp/background" },
+	[] (const ApplicationContext& context) {
+	    CHECK (context.settings.render.wayland.layer == ApplicationContext::WAYLAND_LAYER_BOTTOM);
+	});
+}


### PR DESCRIPTION
Fixes #500

## Implementation summary

Wayland desktop backgrounds now default to the background layer, preserving explicit layer overrides. Added focused parser tests and documentation.

## Changes

```
CMakeLists.txt                                     |  3 +-
 README.md                                          |  3 +-
 .../Application/ApplicationContext.cpp             |  7 ++--
 .../Application/ApplicationContext.h               |  2 +-
 .../Drivers/Output/WaylandOutputViewport.cpp       |  4 ++-
 .../Testing/Cases/ApplicationContext.cpp           | 41 ++++++++++++++++++++++
 6 files changed, 53 insertions(+), 7 deletions(-)
```

## Testing

Yes. Relevant repository checks passed.