### PR TITLE
Fix #448: Any scene wallpaper with multiple audio tracks play at once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,7 @@ if(BUILD_TESTING)
         src/WallpaperEngine/Testing/Input/TestingMouseInput.h
         src/WallpaperEngine/Testing/Harnesses/RenderHarness.cpp
         src/WallpaperEngine/Testing/Harnesses/RenderHarness.h
+        src/WallpaperEngine/Testing/Cases/AudioPlaybackState.cpp
         src/WallpaperEngine/Testing/Cases/MouseCoordinates.cpp
         src/WallpaperEngine/Testing/Cases/PropertyParser.cpp)
 endif()

--- a/src/WallpaperEngine/Audio/AudioPlaybackState.h
+++ b/src/WallpaperEngine/Audio/AudioPlaybackState.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+
+namespace WallpaperEngine::Audio {
+class AudioPlaybackState {
+public:
+    enum class State {
+	Playing,
+	Paused,
+	Stopped,
+    };
+
+    void play () { this->m_state.store (State::Playing); }
+    void pause () { this->m_state.store (State::Paused); }
+
+    std::uint64_t stop () {
+	this->m_state.store (State::Stopped);
+	return this->m_generation.fetch_add (1) + 1;
+    }
+
+    [[nodiscard]] bool isPlaying () const {
+	return this->m_state.load () == State::Playing
+	    && this->m_completedGeneration.load () == this->m_generation.load ();
+    }
+
+    [[nodiscard]] std::uint64_t generation () const { return this->m_generation.load (); }
+    [[nodiscard]] std::uint64_t completedGeneration () const { return this->m_completedGeneration.load (); }
+    [[nodiscard]] bool resetPending () const { return this->completedGeneration () != this->generation (); }
+
+    void markResetComplete (std::uint64_t generation) { this->m_completedGeneration.store (generation); }
+
+    void setVolume (float volume) { this->m_volume.store (std::clamp (volume, 0.0f, 1.0f)); }
+    [[nodiscard]] float volume () const { return this->m_volume.load (); }
+
+private:
+    std::atomic<State> m_state = State::Playing;
+    std::atomic<float> m_volume = 1.0f;
+    std::atomic<std::uint64_t> m_generation = 0;
+    std::atomic<std::uint64_t> m_completedGeneration = 0;
+};
+} // namespace WallpaperEngine::Audio

--- a/src/WallpaperEngine/Audio/AudioStream.cpp
+++ b/src/WallpaperEngine/Audio/AudioStream.cpp
@@ -723,66 +723,77 @@ int AudioStream::resampleAudio (uint8_t* out_buf, const int out_size) {
     return resampled_data_size;
 }
 
-int AudioStream::decodeFrame (uint8_t* audioBuffer, const int bufferSize) {
-	if (this->m_decodeMutex == nullptr) {
-		return 0;
+bool AudioStream::shouldDecode () const {
+    return this->m_audioContext.getApplicationContext ().state.general.keepRunning && this->isInitialized ()
+	&& this->isPlaying ();
+}
+
+int AudioStream::decodeQueuedPacket (uint8_t* audioBuffer, const int bufferSize) {
+    while (this->m_audioPacketSize > 0 && this->shouldDecode ()) {
+	int gotFrame = 0;
+	int ret = avcodec_receive_frame (this->getContext (), this->m_decodeFrame);
+
+	if (ret == 0) {
+	    gotFrame = 1;
+	}
+	if (ret == AVERROR (EAGAIN)) {
+	    ret = 0;
+	}
+	if (ret == 0) {
+	    ret = avcodec_send_packet (this->getContext (), this->m_decodePacket);
+	}
+	if (ret < 0 && ret != AVERROR (EAGAIN)) {
+	    return -1;
 	}
 
-	SDL_LockMutex (this->m_decodeMutex);
-	WallpaperEngine::Data::Utils::ScopeGuard decodeGuard ([this] { SDL_UnlockMutex (this->m_decodeMutex); });
+	if (this->m_decodePacket->size < 0) {
+	    // if error, skip frame
+	    this->m_audioPacketSize = 0;
+	    break;
+	}
+
+	this->m_audioPacketSize -= this->m_decodePacket->size;
+	if (gotFrame == 0) {
+	    continue;
+	}
+
+	const int dataSize = this->resampleAudio (audioBuffer, bufferSize);
+	if (dataSize > 0) {
+	    return dataSize;
+	}
+    }
+
+    return 0;
+}
+
+int AudioStream::decodeFrame (uint8_t* audioBuffer, const int bufferSize) {
+    if (this->m_decodeMutex == nullptr) {
+	return 0;
+    }
+
+    SDL_LockMutex (this->m_decodeMutex);
+    WallpaperEngine::Data::Utils::ScopeGuard decodeGuard ([this] { SDL_UnlockMutex (this->m_decodeMutex); });
 
     // block until there's any data in the buffers
-	while (this->m_audioContext.getApplicationContext ().state.general.keepRunning && this->isInitialized ()
-	       && this->isPlaying ()) {
-		while (this->m_audioPacketSize > 0 && this->m_audioContext.getApplicationContext ().state.general.keepRunning
-		       && this->isInitialized () && this->isPlaying ()) {
-	    int got_frame = 0;
-	    int ret = avcodec_receive_frame (this->getContext (), this->m_decodeFrame);
-
-	    if (ret == 0) {
-		got_frame = 1;
-	    }
-	    if (ret == AVERROR (EAGAIN)) {
-		ret = 0;
-	    }
-	    if (ret == 0) {
-		ret = avcodec_send_packet (this->getContext (), this->m_decodePacket);
-	    }
-	    if (ret < 0 && ret != AVERROR (EAGAIN)) {
-		return -1;
-	    }
-
-	    if (this->m_decodePacket->size < 0) {
-		// if error, skip frame
-			this->m_audioPacketSize = 0;
-			break;
-		    }
-
-		    this->m_audioPacketSize -= this->m_decodePacket->size;
-	    int data_size = 0;
-
-	    if (got_frame) {
-		// audio resampling
-		data_size = this->resampleAudio (audioBuffer, bufferSize);
-	    }
-	    if (data_size <= 0) {
-		// no data found, keep waiting
-		continue;
-	    }
-	    // some data was found
-	    return data_size;
+    while (this->shouldDecode ()) {
+	const int dataSize = this->decodeQueuedPacket (audioBuffer, bufferSize);
+	if (dataSize != 0) {
+	    return dataSize;
+	}
+	if (!this->shouldDecode ()) {
+	    return 0;
 	}
 
 	if (this->m_decodePacket->data) {
 	    av_packet_unref (this->m_decodePacket);
 	}
 
-		if (!this->dequeuePacket ()) {
-		    return 0;
-		}
+	if (!this->dequeuePacket ()) {
+	    return 0;
+	}
 
-		this->m_audioPacketSize = this->m_decodePacket->size;
-	    }
+	this->m_audioPacketSize = this->m_decodePacket->size;
+    }
 
     return 0;
 }

--- a/src/WallpaperEngine/Audio/AudioStream.cpp
+++ b/src/WallpaperEngine/Audio/AudioStream.cpp
@@ -1,5 +1,7 @@
 #include "AudioStream.h"
+#include "WallpaperEngine/Data/Utils/ScopeGuard.h"
 #include "WallpaperEngine/Logging/Log.h"
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <iostream>
@@ -13,14 +15,26 @@ int audio_read_thread (void* arg) {
     auto* stream = static_cast<AudioStream*> (arg);
     AVPacket* packet = av_packet_alloc ();
     int ret = 0;
+    bool inputExhausted = false;
 
     if (waitMutex == nullptr) {
 	sLog.exception ("Cannot create mutex for audio playback waiting");
     }
 
-    while (ret >= 0 && stream->getAudioContext ().getApplicationContext ().state.general.keepRunning
-	   && stream->isInitialized ()) {
-	// give the cpu some time to play the queued frames if there's enough info there
+	while (stream->getAudioContext ().getApplicationContext ().state.general.keepRunning && stream->isInitialized ()) {
+		if (stream->resetPlaybackIfRequested ()) {
+		    inputExhausted = false;
+		    ret = 0;
+		}
+
+		if (inputExhausted) {
+		    SDL_LockMutex (waitMutex);
+		    SDL_CondWaitTimeout (stream->getWaitCondition (), waitMutex, 10);
+		    SDL_UnlockMutex (waitMutex);
+		    continue;
+		}
+
+		// give the cpu some time to play the queued frames if there's enough info there
 	if (stream->getQueueSize () >= MAX_QUEUE_SIZE
 	    || (stream->getQueuePacketCount () > MIN_FRAMES
 		&& (av_q2d (stream->getTimeBase ()) * stream->getQueueDuration () > 1.0))) {
@@ -30,20 +44,29 @@ int audio_read_thread (void* arg) {
 	    continue;
 	}
 
-	ret = av_read_frame (stream->getFormatContext (), packet);
+		ret = av_read_frame (stream->getFormatContext (), packet);
 
-	if (ret == AVERROR_EOF) {
-	    // seek to the beginning of the file again
-	    avformat_seek_file (stream->getFormatContext (), stream->getAudioStream (), 0, 0, 0, ~AVSEEK_FLAG_FRAME);
-	    avcodec_flush_buffers (stream->getContext ());
+		if (ret == AVERROR_EOF) {
+		    if (stream->isRepeat ()) {
+			// Looping is the one case where reaching EOF immediately starts another pass.
+			avformat_seek_file (
+			    stream->getFormatContext (), stream->getAudioStream (), 0, 0, 0, ~AVSEEK_FLAG_FRAME
+			);
+			avcodec_flush_buffers (stream->getContext ());
+			ret = 0;
+		    } else {
+			// Keep the reader thread alive so SceneScript stop()/play() can rewind
+			// and reuse a non-looping sound layer later.
+			inputExhausted = true;
+			ret = 0;
+		    }
 
-	    // ensure the thread is not killed if audio has to be looped
-	    if (stream->isRepeat ()) {
-		ret = 0;
-	    }
+		    continue;
+		}
 
-	    continue;
-	}
+		if (ret < 0) {
+		    break;
+		}
 
 	// TODO: PROPERLY IMPLEMENT THIS
 	if (packet->stream_index == stream->getAudioStream ()) {
@@ -54,6 +77,7 @@ int audio_read_thread (void* arg) {
     }
 
     // stop the audio too just in case
+    av_packet_free (&packet);
     SDL_DestroyMutex (waitMutex);
 
     return 0;
@@ -151,8 +175,9 @@ AudioStream::~AudioStream () {
     this->m_audioThread = nullptr;
 
     if (this->m_queue != nullptr) {
-	// wait for the audio buffers to be done
-	SDL_CondWait (this->m_queue->wait, this->m_queue->mutex);
+		SDL_LockMutex (this->m_queue->mutex);
+		this->clearQueueLocked ();
+		SDL_UnlockMutex (this->m_queue->mutex);
     }
 
     if (this->m_swrctx != nullptr && swr_is_initialized (this->m_swrctx) == true) {
@@ -176,7 +201,18 @@ AudioStream::~AudioStream () {
 #endif /* FF_API_FIFO_OLD_API */
     }
 
-    delete this->m_queue;
+    if (this->m_queue != nullptr) {
+		SDL_DestroyCond (this->m_queue->wait);
+		SDL_DestroyCond (this->m_queue->cond);
+		SDL_DestroyMutex (this->m_queue->mutex);
+		delete this->m_queue;
+		this->m_queue = nullptr;
+    }
+
+	if (this->m_decodeMutex != nullptr) {
+		SDL_DestroyMutex (this->m_decodeMutex);
+		this->m_decodeMutex = nullptr;
+	}
 
     if (this->m_formatContext != nullptr) {
 	avformat_free_context (this->m_formatContext);
@@ -306,6 +342,7 @@ void AudioStream::initialize () {
     this->m_queue->mutex = SDL_CreateMutex ();
     this->m_queue->cond = SDL_CreateCond ();
     this->m_queue->wait = SDL_CreateCond ();
+	this->m_decodeMutex = SDL_CreateMutex ();
 
     this->m_decodeFrame = av_frame_alloc ();
     this->m_decodePacket = av_packet_alloc ();
@@ -317,7 +354,12 @@ void AudioStream::initialize () {
 	sLog.exception ("Could not allocate AVPacket.\n");
     }
 
-    this->m_initialized = true;
+	if (this->m_queue->mutex == nullptr || this->m_queue->cond == nullptr || this->m_queue->wait == nullptr
+	    || this->m_decodeMutex == nullptr) {
+		sLog.exception ("Could not initialize audio synchronization primitives");
+	}
+
+	this->m_initialized.store (true);
 }
 
 void AudioStream::queuePacket (AVPacket* pkt) {
@@ -367,12 +409,14 @@ bool AudioStream::doQueue (AVPacket* pkt) {
     return true;
 }
 
-void AudioStream::dequeuePacket () {
+bool AudioStream::dequeuePacket () {
     MyAVPacketList entry {};
+	bool dequeued = false;
 
     SDL_LockMutex (this->m_queue->mutex);
 
-    while (this->m_audioContext.getApplicationContext ().state.general.keepRunning) {
+	while (this->m_audioContext.getApplicationContext ().state.general.keepRunning && this->isInitialized ()
+	       && this->isPlaying ()) {
 #if FF_API_FIFO_OLD_API
 	int ret = -1;
 
@@ -390,9 +434,10 @@ void AudioStream::dequeuePacket () {
 	    this->m_queue->duration -= entry.packet->duration;
 
 	    // move the reference and free the old one
-	    av_packet_move_ref (this->m_decodePacket, entry.packet);
-	    av_packet_free (&entry.packet);
-	    break;
+		    av_packet_move_ref (this->m_decodePacket, entry.packet);
+		    av_packet_free (&entry.packet);
+		    dequeued = true;
+		    break;
 	}
 
 	// make the thread wait if nothing was available
@@ -400,6 +445,7 @@ void AudioStream::dequeuePacket () {
     }
 
     SDL_UnlockMutex (this->m_queue->mutex);
+	return dequeued;
 }
 
 AVCodecContext* AudioStream::getContext () const { return this->m_context; }
@@ -408,11 +454,119 @@ AVFormatContext* AudioStream::getFormatContext () const { return this->m_formatC
 
 int AudioStream::getAudioStream () const { return this->m_audioStream; }
 
-bool AudioStream::isInitialized () const { return this->m_initialized; }
+bool AudioStream::isInitialized () const { return this->m_initialized.load (); }
 
-void AudioStream::setRepeat (const bool newRepeat) { this->m_repeat = newRepeat; }
+void AudioStream::setRepeat (const bool newRepeat) { this->m_repeat.store (newRepeat); }
 
-bool AudioStream::isRepeat () const { return this->m_repeat; }
+bool AudioStream::isRepeat () const { return this->m_repeat.load (); }
+
+void AudioStream::play () {
+    if (!this->isInitialized ()) {
+		return;
+    }
+
+	this->m_playback.play ();
+	SDL_CondBroadcast (this->m_queue->cond);
+	SDL_CondBroadcast (this->m_queue->wait);
+}
+
+void AudioStream::pause () {
+    if (!this->isInitialized ()) {
+		return;
+    }
+
+	this->m_playback.pause ();
+	SDL_CondBroadcast (this->m_queue->cond);
+}
+
+void AudioStream::stopPlayback () {
+    if (!this->isInitialized ()) {
+		return;
+    }
+
+	this->m_playback.stop ();
+	SDL_CondBroadcast (this->m_queue->cond);
+	SDL_CondBroadcast (this->m_queue->wait);
+}
+
+bool AudioStream::isPlaying () const {
+    return this->m_playback.isPlaying ();
+}
+
+void AudioStream::setVolume (float volume) { this->m_playback.setVolume (volume); }
+
+float AudioStream::getVolume () const { return this->m_playback.volume (); }
+
+std::uint64_t AudioStream::getPlaybackGeneration () const { return this->m_playback.generation (); }
+
+void AudioStream::clearQueueLocked () {
+    if (this->m_queue == nullptr || this->m_queue->packetList == nullptr) {
+		return;
+    }
+
+	while (this->m_queue->nb_packets > 0) {
+		MyAVPacketList entry {};
+#if FF_API_FIFO_OLD_API
+		if (av_fifo_size (this->m_queue->packetList) < static_cast<int> (sizeof (entry))
+		    || av_fifo_generic_read (this->m_queue->packetList, &entry, sizeof (entry), nullptr) < 0) {
+		    break;
+		}
+#else
+		if (av_fifo_read (this->m_queue->packetList, &entry, 1) < 0) {
+		    break;
+		}
+#endif
+		if (entry.packet != nullptr) {
+		    av_packet_free (&entry.packet);
+		}
+	}
+
+	this->m_queue->nb_packets = 0;
+	this->m_queue->size = 0;
+	this->m_queue->duration = 0;
+}
+
+bool AudioStream::resetPlaybackIfRequested () {
+	if (!this->m_playback.resetPending () || this->m_decodeMutex == nullptr || this->m_queue == nullptr) {
+		return false;
+	}
+
+	SDL_LockMutex (this->m_decodeMutex);
+	const auto generation = this->m_playback.generation ();
+	if (this->m_playback.completedGeneration () == generation) {
+		SDL_UnlockMutex (this->m_decodeMutex);
+		return false;
+	}
+
+	SDL_LockMutex (this->m_queue->mutex);
+	this->clearQueueLocked ();
+	SDL_UnlockMutex (this->m_queue->mutex);
+
+	if (this->m_formatContext != nullptr && this->m_audioStream != NO_AUDIO_STREAM) {
+		if (avformat_seek_file (this->m_formatContext, this->m_audioStream, 0, 0, 0, ~AVSEEK_FLAG_FRAME) < 0) {
+		    sLog.error ("Failed to rewind audio stream");
+		}
+	}
+	if (this->m_context != nullptr) {
+		avcodec_flush_buffers (this->m_context);
+	}
+	if (this->m_decodePacket != nullptr) {
+		av_packet_unref (this->m_decodePacket);
+	}
+	if (this->m_decodeFrame != nullptr) {
+		av_frame_unref (this->m_decodeFrame);
+	}
+	if (this->m_swrctx != nullptr) {
+		swr_close (this->m_swrctx);
+		if (swr_init (this->m_swrctx) < 0) {
+		    sLog.error ("Failed to reset audio resampler");
+		}
+	}
+	this->m_audioPacketSize = 0;
+	this->m_playback.markResetComplete (generation);
+	SDL_UnlockMutex (this->m_decodeMutex);
+	return true;
+}
 
 ReadStreamSharedPtr& AudioStream::getBuffer () { return this->m_buffer; }
 
@@ -437,12 +591,15 @@ bool AudioStream::isQueueEmpty () const { return this->m_queue->nb_packets == 0;
 SDL_mutex* AudioStream::getMutex () const { return this->m_queue->mutex; }
 
 void AudioStream::stop () {
-    if (!this->isInitialized ()) {
-	return;
-    }
+	if (!this->m_initialized.exchange (false)) {
+		return;
+	    }
 
-    // stop the threads running
-    this->m_initialized = false;
+	this->m_playback.pause ();
+	if (this->m_queue != nullptr) {
+		SDL_CondBroadcast (this->m_queue->cond);
+		SDL_CondBroadcast (this->m_queue->wait);
+	}
 }
 
 int AudioStream::resampleAudio (uint8_t* out_buf, const int out_size) {
@@ -567,11 +724,18 @@ int AudioStream::resampleAudio (uint8_t* out_buf, const int out_size) {
 }
 
 int AudioStream::decodeFrame (uint8_t* audioBuffer, const int bufferSize) {
-    static int audio_pkt_size = 0;
+	if (this->m_decodeMutex == nullptr) {
+		return 0;
+	}
+
+	SDL_LockMutex (this->m_decodeMutex);
+	WallpaperEngine::Data::Utils::ScopeGuard decodeGuard ([this] { SDL_UnlockMutex (this->m_decodeMutex); });
 
     // block until there's any data in the buffers
-    while (this->m_audioContext.getApplicationContext ().state.general.keepRunning) {
-	while (audio_pkt_size > 0 && this->m_audioContext.getApplicationContext ().state.general.keepRunning) {
+	while (this->m_audioContext.getApplicationContext ().state.general.keepRunning && this->isInitialized ()
+	       && this->isPlaying ()) {
+		while (this->m_audioPacketSize > 0 && this->m_audioContext.getApplicationContext ().state.general.keepRunning
+		       && this->isInitialized () && this->isPlaying ()) {
 	    int got_frame = 0;
 	    int ret = avcodec_receive_frame (this->getContext (), this->m_decodeFrame);
 
@@ -590,11 +754,11 @@ int AudioStream::decodeFrame (uint8_t* audioBuffer, const int bufferSize) {
 
 	    if (this->m_decodePacket->size < 0) {
 		// if error, skip frame
-		audio_pkt_size = 0;
-		break;
-	    }
+			this->m_audioPacketSize = 0;
+			break;
+		    }
 
-	    audio_pkt_size -= this->m_decodePacket->size;
+		    this->m_audioPacketSize -= this->m_decodePacket->size;
 	    int data_size = 0;
 
 	    if (got_frame) {
@@ -613,10 +777,12 @@ int AudioStream::decodeFrame (uint8_t* audioBuffer, const int bufferSize) {
 	    av_packet_unref (this->m_decodePacket);
 	}
 
-	this->dequeuePacket ();
+		if (!this->dequeuePacket ()) {
+		    return 0;
+		}
 
-	audio_pkt_size = this->m_decodePacket->size;
-    }
+		this->m_audioPacketSize = this->m_decodePacket->size;
+	    }
 
     return 0;
 }

--- a/src/WallpaperEngine/Audio/AudioStream.h
+++ b/src/WallpaperEngine/Audio/AudioStream.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <cstdint>
 #include <string>
 
 extern "C" {
@@ -15,6 +17,7 @@ extern "C" {
 #include <SDL_thread.h>
 
 #include "WallpaperEngine/Audio/AudioContext.h"
+#include "WallpaperEngine/Audio/AudioPlaybackState.h"
 
 // TODO: FIND A BETTER PLACE TO DO THIS? OLD_API MIGHT EXIST BUT THIS DEFINE MIGHT NOT BE DEFINED...
 #ifndef FF_API_FIFO_OLD_API
@@ -52,7 +55,7 @@ public:
      *
      * @return
      */
-    void dequeuePacket ();
+    bool dequeuePacket ();
 
     /**
      * @return The audio context in use for this audio stream
@@ -83,6 +86,21 @@ public:
      * @return If the stream is to be repeated at the end or not
      */
     [[nodiscard]] bool isRepeat () const;
+    /** Resume playback from the current position, or from the beginning after stopPlayback(). */
+    void play ();
+    /** Pause playback while preserving the current decoder and SDL buffer position. */
+    void pause ();
+    /** Stop playback and request a rewind to the beginning without destroying the decoder. */
+    void stopPlayback ();
+    /** @return Whether this stream should currently be mixed into the audio output. */
+    [[nodiscard]] bool isPlaying () const;
+    /** Layer-local gain in the [0, 1] range. */
+    void setVolume (float volume);
+    [[nodiscard]] float getVolume () const;
+    /** Used by the SDL driver to discard buffered audio after a stop/rewind. */
+    [[nodiscard]] std::uint64_t getPlaybackGeneration () const;
+    /** Services a pending stop/rewind request on the FFmpeg reader thread. */
+    bool resetPlaybackIfRequested ();
     /**
      * Stops decoding and playback of the stream
      */
@@ -152,6 +170,8 @@ private:
      * @return
      */
     bool doQueue (AVPacket* pkt);
+    /** Frees all queued packets. The caller must hold m_queue->mutex. */
+    void clearQueueLocked ();
     /**
      * Initializes queues and ffmpeg resampling
      */
@@ -162,9 +182,10 @@ private:
     /** The audio context this stream will be played under */
     AudioContext& m_audioContext;
     /** If this stream was properly initialized or not */
-    bool m_initialized = false;
+    std::atomic<bool> m_initialized = false;
     /** Repeat enabled? */
-    bool m_repeat = false;
+    std::atomic<bool> m_repeat = false;
+    AudioPlaybackState m_playback;
     /** The codec context that contains the original audio format information */
     AVCodecContext* m_context = nullptr;
     /** The format context that controls how data is read off the file */
@@ -182,6 +203,10 @@ private:
     AVPacket* m_decodePacket = nullptr;
     /** The AV frame used while decoding this stream */
     AVFrame* m_decodeFrame = nullptr;
+    /** Remaining bytes in m_decodePacket for this stream (must not be shared between streams). */
+    int m_audioPacketSize = 0;
+    /** Serializes decoder state with stop/rewind resets. */
+    SDL_mutex* m_decodeMutex = nullptr;
 
     /**
      * Packet queue information

--- a/src/WallpaperEngine/Audio/AudioStream.h
+++ b/src/WallpaperEngine/Audio/AudioStream.h
@@ -164,6 +164,14 @@ private:
      */
     int resampleAudio (uint8_t* out_buf, const int out_size);
     /**
+     * Decodes the currently queued packet while playback remains active.
+     *
+     * @return Resampled bytes, a negative value on decode error, or 0 when the packet is exhausted/paused.
+     */
+    int decodeQueuedPacket (uint8_t* audioBuffer, int bufferSize);
+    /** @return Whether decoding should continue for the current playback state. */
+    [[nodiscard]] bool shouldDecode () const;
+    /**
      * Queues a packet into the play queue
      *
      * @param pkt

--- a/src/WallpaperEngine/Audio/Drivers/SDLAudioDriver.cpp
+++ b/src/WallpaperEngine/Audio/Drivers/SDLAudioDriver.cpp
@@ -1,6 +1,9 @@
 #include "SDLAudioDriver.h"
 #include "WallpaperEngine/Logging/Log.h"
 
+#include <algorithm>
+#include <cmath>
+
 #define SDL_AUDIO_BUFFER_SIZE 4096
 #define MAX_AUDIO_FRAME_SIZE 192000
 
@@ -20,14 +23,19 @@ void audio_callback (void* userdata, uint8_t* streamData, int length) {
     SDL_LockMutex (driver->getStreamMutex ());
 
     for (const auto& buffer : driver->getStreams () | std::views::values) {
-	uint8_t* streamDataPointer = streamData;
-	int streamLength = length;
+		uint8_t* streamDataPointer = streamData;
+		int streamLength = length;
+		const auto playbackGeneration = buffer->stream->getPlaybackGeneration ();
+		if (buffer->playbackGeneration != playbackGeneration) {
+		    buffer->audio_buf_size = 0;
+		    buffer->audio_buf_index = 0;
+		    buffer->playbackGeneration = playbackGeneration;
+		}
 
-	// sound is not initialized or stopped and is not in loop mode
-	// ignore mixing it in
-	if (!buffer->stream->isInitialized ()) {
-	    continue;
-	}
+		// Paused/stopped layers remain registered, but they must not advance or mix.
+		if (!buffer->stream->isInitialized () || !buffer->stream->isPlaying ()) {
+		    continue;
+		}
 
 	// check if queue is empty and signal the read thread
 	if (buffer->stream->isQueueEmpty ()) {
@@ -44,6 +52,12 @@ void audio_callback (void* userdata, uint8_t* streamData, int length) {
 		    // fallback for errors, silence
 		    buffer->audio_buf_size = 1024;
 		    memset (buffer->audio_buf, 0, buffer->audio_buf_size);
+		} else if (audio_size == 0) {
+		    // Playback may have been paused/stopped after entering this callback.
+		    // Do not spin on an empty buffer while holding the stream-list mutex.
+		    buffer->audio_buf_size = 0;
+		    buffer->audio_buf_index = 0;
+		    break;
 		} else {
 		    buffer->audio_buf_size = audio_size;
 		}
@@ -57,11 +71,17 @@ void audio_callback (void* userdata, uint8_t* streamData, int length) {
 		len1 = streamLength;
 	    }
 
-	    // mix the audio
-	    SDL_MixAudioFormat (
-		streamDataPointer, &buffer->audio_buf[buffer->audio_buf_index], driver->getSpec ().format, len1,
-		driver->getApplicationContext ().state.audio.volume
-	    );
+		    // Layer volume is a multiplier on the existing global volume control.
+		    const int volume = std::clamp (
+			static_cast<int> (std::lround (
+			    driver->getApplicationContext ().state.audio.volume * buffer->stream->getVolume ()
+			)),
+			0, SDL_MIX_MAXVOLUME
+		    );
+		    SDL_MixAudioFormat (
+			streamDataPointer, &buffer->audio_buf[buffer->audio_buf_index], driver->getSpec ().format, len1,
+			volume
+		    );
 
 	    streamLength -= len1;
 	    streamDataPointer += len1;
@@ -107,15 +127,22 @@ SDLAudioDriver::SDLAudioDriver (
 }
 
 SDLAudioDriver::~SDLAudioDriver () {
-    if (!this->m_initialized) {
-	return;
-    }
+	if (this->m_initialized && this->m_deviceID != 0) {
+		SDL_CloseAudioDevice (this->m_deviceID);
+	    }
 
-    if (this->m_deviceID != 0) {
-	SDL_CloseAudioDevice (this->m_deviceID);
-    }
+	SDL_LockMutex (this->m_streamListMutex);
+	for (auto* buffer : this->m_streams | std::views::values) {
+		delete buffer;
+	}
+	this->m_streams.clear ();
+	SDL_UnlockMutex (this->m_streamListMutex);
+	SDL_DestroyMutex (this->m_streamListMutex);
+	this->m_streamListMutex = nullptr;
 
-    SDL_QuitSubSystem (SDL_INIT_AUDIO);
+	if (this->m_initialized) {
+		SDL_QuitSubSystem (SDL_INIT_AUDIO);
+	}
 }
 
 int SDLAudioDriver::addStream (AudioStream* stream) {
@@ -130,7 +157,15 @@ int SDLAudioDriver::addStream (AudioStream* stream) {
 
     return newStreamId;
 }
-void SDLAudioDriver::removeStream (int streamId) { this->m_streams.erase (streamId); }
+void SDLAudioDriver::removeStream (int streamId) {
+    SDL_LockMutex (this->m_streamListMutex);
+	const auto stream = this->m_streams.find (streamId);
+	if (stream != this->m_streams.end ()) {
+		delete stream->second;
+		this->m_streams.erase (stream);
+	}
+	SDL_UnlockMutex (this->m_streamListMutex);
+}
 
 const std::map<int, SDLAudioBuffer*>& SDLAudioDriver::getStreams () { return this->m_streams; }
 

--- a/src/WallpaperEngine/Audio/Drivers/SDLAudioDriver.h
+++ b/src/WallpaperEngine/Audio/Drivers/SDLAudioDriver.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <vector>
 
@@ -19,6 +20,7 @@ struct SDLAudioBuffer {
     uint8_t audio_buf[(MAX_AUDIO_FRAME_SIZE * 3) / 2] = { 0 };
     unsigned int audio_buf_size = 0;
     unsigned int audio_buf_index = 0;
+    std::uint64_t playbackGeneration = 0;
 };
 
 /**

--- a/src/WallpaperEngine/Render/Objects/CSound.cpp
+++ b/src/WallpaperEngine/Render/Objects/CSound.cpp
@@ -2,11 +2,15 @@
 
 #include "CSound.h"
 
+#include <algorithm>
+#include <ranges>
+
 #include "WallpaperEngine/FileSystem/Container.h"
 
 using namespace WallpaperEngine::Render::Objects;
 
-CSound::CSound (Wallpapers::CScene& scene, const Sound& sound) : CObject (scene, sound), m_sound (sound) {
+CSound::CSound (Wallpapers::CScene& scene, const Sound& sound) :
+    CObject (scene, sound), Scripting::ScriptableObject (scene, sound), m_sound (sound) {
     if (this->getContext ().getApp ().getContext ().settings.audio.enabled) {
 	this->load ();
     }
@@ -27,7 +31,8 @@ void CSound::load () {
 	auto stream
 	    = new Audio::AudioStream (this->getScene ().getAudioContext (), this->getAssetLocator ().read (cur));
 
-	stream->setRepeat (this->m_sound.playbackmode.has_value () && this->m_sound.playbackmode == "loop");
+		stream->setRepeat (this->m_sound.playbackmode.has_value () && this->m_sound.playbackmode == "loop");
+		stream->setVolume (this->m_volume);
 
 	// add the stream to the context so it can be played
 	this->m_audioStreams.insert_or_assign (this->getScene ().getAudioContext ().addStream (stream), stream);
@@ -35,3 +40,36 @@ void CSound::load () {
 }
 
 void CSound::render () { }
+
+void CSound::play () {
+    for (const auto& stream : this->m_audioStreams | std::views::values) {
+		stream->play ();
+    }
+}
+
+void CSound::pause () {
+    for (const auto& stream : this->m_audioStreams | std::views::values) {
+		stream->pause ();
+    }
+}
+
+void CSound::stop () {
+    for (const auto& stream : this->m_audioStreams | std::views::values) {
+		stream->stopPlayback ();
+    }
+}
+
+bool CSound::isPlaying () const {
+    return std::ranges::any_of (this->m_audioStreams | std::views::values, [] (const auto* stream) {
+		return stream->isPlaying ();
+    });
+}
+
+float CSound::getVolume () const { return this->m_volume; }
+
+void CSound::setVolume (float volume) {
+    this->m_volume = std::clamp (volume, 0.0f, 1.0f);
+    for (const auto& stream : this->m_audioStreams | std::views::values) {
+		stream->setVolume (this->m_volume);
+    }
+}

--- a/src/WallpaperEngine/Render/Objects/CSound.h
+++ b/src/WallpaperEngine/Render/Objects/CSound.h
@@ -2,6 +2,7 @@
 
 #include "WallpaperEngine/Audio/AudioStream.h"
 #include "WallpaperEngine/Render/CObject.h"
+#include "WallpaperEngine/Scripting/ScriptableObject.h"
 
 using namespace WallpaperEngine;
 
@@ -12,12 +13,19 @@ class CScene;
 namespace WallpaperEngine::Render::Objects {
 using namespace WallpaperEngine::Data::Model;
 
-class CSound final : public CObject {
+class CSound final : public Scripting::ScriptableObject {
 public:
     CSound (Wallpapers::CScene& scene, const Sound& sound);
     ~CSound () override;
 
     void render () override;
+
+    void play ();
+    void pause ();
+    void stop ();
+    [[nodiscard]] bool isPlaying () const;
+    [[nodiscard]] float getVolume () const;
+    void setVolume (float volume);
 
 protected:
     void load ();
@@ -26,5 +34,6 @@ private:
     std::map<int, Audio::AudioStream*> m_audioStreams = {};
 
     const Sound& m_sound;
+    float m_volume = 1.0f;
 };
 } // namespace WallpaperEngine::Render::Objects

--- a/src/WallpaperEngine/Scripting/Adapters/ScriptableObjectAdapter.cpp
+++ b/src/WallpaperEngine/Scripting/Adapters/ScriptableObjectAdapter.cpp
@@ -1,8 +1,10 @@
 #include "ScriptableObjectAdapter.h"
 
+#include <cstring>
 #include <utility>
 
 #include "WallpaperEngine/Data/Utils/ScopeGuard.h"
+#include "WallpaperEngine/Render/Objects/CSound.h"
 #include "WallpaperEngine/Scripting/ScriptEngine.h"
 #include "WallpaperEngine/Scripting/ScriptableObject.h"
 
@@ -18,14 +20,76 @@ struct OpaqueScriptableObjectAdapter {
     WallpaperEngine::Scripting::ScriptableObject& object;
 };
 
-JSValue scriptableobject_property_get (JSContext* ctx, JSValueConst obj_val, JSAtom atom, JSValueConst receiver) {
+static OpaqueScriptableObjectAdapter* get_scriptable_object (JSValueConst value) {
     JSClassID classId = 0;
+    auto* container = static_cast<OpaqueScriptableObjectAdapter*> (JS_GetAnyOpaque (value, &classId));
+    return container != nullptr && container->magic == SCRIPTABLE_OPAQUE_MAGIC ? container : nullptr;
+}
 
-    auto* container = static_cast<OpaqueScriptableObjectAdapter*> (JS_GetAnyOpaque (obj_val, &classId));
-
-    if (!container || container->magic != SCRIPTABLE_OPAQUE_MAGIC) {
-	return JS_EXCEPTION;
+static WallpaperEngine::Render::Objects::CSound* get_sound (JSValueConst value) {
+    auto* container = get_scriptable_object (value);
+    if (container == nullptr || !container->object.is<WallpaperEngine::Render::Objects::CSound> ()) {
+		return nullptr;
     }
+
+    return container->object.as<WallpaperEngine::Render::Objects::CSound> ();
+}
+
+JSValue scriptableobject_get_children (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    auto* container = get_scriptable_object (this_val);
+    if (container == nullptr) {
+		return JS_EXCEPTION;
+    }
+
+    JSValue result = JS_NewArray (ctx);
+    uint32_t index = 0;
+    for (auto* child : container->object.getChildren ()) {
+		JS_SetPropertyUint32 (ctx, result, index++, container->adapter.instantiate (*child));
+    }
+
+    return result;
+}
+
+JSValue scriptableobject_sound_is_playing (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    auto* sound = get_sound (this_val);
+    return sound == nullptr ? JS_UNDEFINED : JS_NewBool (ctx, sound->isPlaying ());
+}
+
+JSValue scriptableobject_sound_play (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    auto* sound = get_sound (this_val);
+    if (sound != nullptr) {
+		sound->play ();
+    }
+    return JS_UNDEFINED;
+}
+
+JSValue scriptableobject_sound_pause (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    auto* sound = get_sound (this_val);
+    if (sound != nullptr) {
+		sound->pause ();
+    }
+    return JS_UNDEFINED;
+}
+
+JSValue scriptableobject_sound_stop (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    auto* sound = get_sound (this_val);
+    if (sound != nullptr) {
+		sound->stop ();
+    }
+    return JS_UNDEFINED;
+}
+
+void scriptableobject_finalizer (JSRuntime* rt, JSValueConst val) {
+    auto* container = get_scriptable_object (val);
+    delete container;
+}
+
+JSValue scriptableobject_property_get (JSContext* ctx, JSValueConst obj_val, JSAtom atom, JSValueConst receiver) {
+	    auto* container = get_scriptable_object (obj_val);
+
+	    if (container == nullptr) {
+		return JS_EXCEPTION;
+	    }
 
     const char* name = JS_AtomToCString (ctx, atom);
 
@@ -34,6 +98,32 @@ JSValue scriptableobject_property_get (JSContext* ctx, JSValueConst obj_val, JSA
     }
 
     ScopeGuard guard ([=] { JS_FreeCString (ctx, name); });
+
+	    if (strcmp (name, "name") == 0) {
+		return JS_NewString (ctx, container->object.getObject ().name.c_str ());
+	    }
+	    if (strcmp (name, "getChildren") == 0) {
+		return JS_NewCFunction (ctx, scriptableobject_get_children, "getChildren", 0);
+	    }
+
+	    if (container->object.is<WallpaperEngine::Render::Objects::CSound> ()) {
+		auto* sound = container->object.as<WallpaperEngine::Render::Objects::CSound> ();
+		if (strcmp (name, "volume") == 0) {
+		    return JS_NewFloat64 (ctx, sound->getVolume ());
+		}
+		if (strcmp (name, "isPlaying") == 0) {
+		    return JS_NewCFunction (ctx, scriptableobject_sound_is_playing, "isPlaying", 0);
+		}
+		if (strcmp (name, "play") == 0) {
+		    return JS_NewCFunction (ctx, scriptableobject_sound_play, "play", 0);
+		}
+		if (strcmp (name, "pause") == 0) {
+		    return JS_NewCFunction (ctx, scriptableobject_sound_pause, "pause", 0);
+		}
+		if (strcmp (name, "stop") == 0) {
+		    return JS_NewCFunction (ctx, scriptableobject_sound_stop, "stop", 0);
+		}
+	    }
 
     try {
 	// find the property inside, otherwise return undefined
@@ -48,30 +138,44 @@ JSValue scriptableobject_property_get (JSContext* ctx, JSValueConst obj_val, JSA
 int scriptableobject_property_set (
     JSContext* ctx, JSValueConst obj_val, JSAtom atom, JSValueConst val, JSValueConst receiver, int flags
 ) {
-    JSClassID classId = 0;
+	    auto* container = get_scriptable_object (obj_val);
 
-    auto* container = static_cast<OpaqueScriptableObjectAdapter*> (JS_GetAnyOpaque (obj_val, &classId));
-
-    if (!container || container->magic != SCRIPTABLE_OPAQUE_MAGIC) {
-	return -1;
-    }
+	    if (container == nullptr) {
+		return -1;
+	    }
 
     const char* name = JS_AtomToCString (ctx, atom);
 
-    if (name == nullptr) {
-	return -1;
-    }
+	    if (name == nullptr) {
+		return -1;
+	    }
 
-    return 0;
+	    ScopeGuard guard ([=] { JS_FreeCString (ctx, name); });
+
+	    if (strcmp (name, "volume") == 0 && container->object.is<WallpaperEngine::Render::Objects::CSound> ()) {
+		if (!JS_IsNumber (val)) {
+		    return -1;
+		}
+
+		double volume = 0.0;
+		if (JS_ToFloat64 (ctx, &volume, val) < 0) {
+		    return -1;
+		}
+
+		container->object.as<WallpaperEngine::Render::Objects::CSound> ()->setVolume (static_cast<float> (volume));
+	    }
+
+	    return 0;
 }
 
 ScriptableObjectAdapter::ScriptableObjectAdapter (ScriptEngine& engine, std::string name) :
     ObjectAdapter (engine), m_exoticMethods (), m_name (std::move (name)) {
     this->registerType (
-	{
-	    .class_name = m_name.c_str (),
-	    .exotic = &m_exoticMethods,
-	}
+		{
+		    .class_name = m_name.c_str (),
+		    .finalizer = scriptableobject_finalizer,
+		    .exotic = &m_exoticMethods,
+		}
     );
 }
 

--- a/src/WallpaperEngine/Scripting/ScriptEngine.cpp
+++ b/src/WallpaperEngine/Scripting/ScriptEngine.cpp
@@ -252,7 +252,8 @@ ScriptEngine::~ScriptEngine () {
     this->m_unregisterMediaUpdateCallback ();
 
     for (const auto& module : this->m_scriptModules | std::views::values) {
-	JS_FreeValue (this->m_context, module.module);
+		JS_FreeValue (this->m_context, module.module);
+		JS_FreeValue (this->m_context, module.thisLayer);
     }
 
     JS_FreeValue (this->m_context, this->m_globalThis);
@@ -564,6 +565,13 @@ JSValue ScriptEngine::call (JSValue module, int argc, JSValue argv[], const char
     return JS_Call (this->m_context, function, module, argc, argv);
 }
 
+void ScriptEngine::bindModule (LoadedModule& module) {
+    this->m_runningModule = &module;
+    JS_SetPropertyStr (
+		this->m_context, this->m_globalThis, "thisLayer", JS_DupValue (this->m_context, module.thisLayer)
+    );
+}
+
 void ScriptEngine::queueScript (const std::string& key, DynamicValue& currentValue, ScriptableObject& object) {
     const auto source = currentValue.getScriptSource ();
 
@@ -577,40 +585,47 @@ void ScriptEngine::queueScript (const std::string& key, DynamicValue& currentVal
 	return;
     }
 
-    // load the script and store it
-    JSValue module = JS_Eval (this->m_context, source->c_str (), source->size (), key.c_str (), JS_EVAL_TYPE_MODULE);
-
-    auto inserted = this->m_scriptModules.emplace (
-	key,
-	LoadedModule {
+	// Bind thisLayer before module evaluation. Script properties are constructed at
+	// module scope and need to resolve against the DynamicValue currently loading.
+	JSValue thisLayer = this->m_adapters.object->instantiate (object);
+	JS_SetPropertyStr (
+		this->m_context, this->m_globalThis, "thisLayer", JS_DupValue (this->m_context, thisLayer)
+	);
+	LoadedModule loadingModule {
 	    .value = currentValue,
-	    .module = module,
+	    .object = object,
+	    .module = JS_UNDEFINED,
+	    .thisLayer = thisLayer,
+	};
+	this->m_runningModule = &loadingModule;
+
+	// Load the script now, but defer init/update until the first scene tick. By
+	// then the complete layer graph is available to thisLayer.getChildren().
+	JSValue module = JS_Eval (this->m_context, source->c_str (), source->size (), key.c_str (), JS_EVAL_TYPE_MODULE);
+	this->m_runningModule = nullptr;
+
+	if (JS_IsException (module)) {
+	    logJSException (this->m_context, key.c_str ());
+	    JS_FreeValue (this->m_context, module);
+	    JS_FreeValue (this->m_context, thisLayer);
+	    return;
 	}
-    );
 
-    if (!inserted.second) {
-	return;
-    }
+	auto inserted = this->m_scriptModules.emplace (
+		key,
+		LoadedModule {
+		    .value = currentValue,
+		    .object = object,
+		    .module = module,
+		    .thisLayer = thisLayer,
+		}
+	    );
 
-    JS_SetPropertyStr (this->m_context, this->m_globalThis, "thisLayer", this->m_adapters.object->instantiate (object));
-
-    // script properties do not need update as they're connected directly to the source data
-    this->m_runningModule = &inserted.first->second;
-
-    // check if there's an update method and run it
-    JSValue args[] = { this->dynamicToJs (currentValue) };
-    JSValue result = this->call (module, 1, args, "update");
-
-    ScopeGuard guard2 ([this, args, result] () {
-	JS_FreeValue (this->m_context, result);
-	JS_FreeValue (this->m_context, args[0]);
-    });
-
-    if (JS_IsException (result)) {
-	return;
-    }
-
-    jsToDynamicValue (this->m_context, result, currentValue);
+	    if (!inserted.second) {
+		JS_FreeValue (this->m_context, module);
+		JS_FreeValue (this->m_context, thisLayer);
+		return;
+	    }
 }
 
 void ScriptEngine::tick () {
@@ -621,12 +636,22 @@ void ScriptEngine::tick () {
 
     // run all update methods
     for (auto& module : this->m_scriptModules | std::views::values) {
-	this->m_runningModule = &module;
+		this->bindModule (module);
 
-	JSValue args[] = { this->dynamicToJs (module.value) };
-	JSValue result = this->call (module.module, 1, args, "update");
-	ScopeGuard guard ([result, args, this] () {
-	    JS_FreeValue (this->m_context, result);
+		JSValue args[] = { this->dynamicToJs (module.value) };
+
+		if (!module.initialized) {
+		    module.initialized = true;
+		    JSValue initResult = this->call (module.module, 1, args, "init");
+		    if (JS_IsException (initResult)) {
+			logJSException (this->m_context, "init");
+		    }
+		    JS_FreeValue (this->m_context, initResult);
+		}
+
+		JSValue result = this->call (module.module, 1, args, "update");
+		ScopeGuard guard ([result, args, this] () {
+		    JS_FreeValue (this->m_context, result);
 	    JS_FreeValue (this->m_context, args[0]);
 	});
 
@@ -634,8 +659,10 @@ void ScriptEngine::tick () {
 	    continue;
 	}
 
-	jsToDynamicValue (this->m_context, result, module.value);
-    }
+		jsToDynamicValue (this->m_context, result, module.value);
+	    }
+
+	    this->m_runningModule = nullptr;
 }
 
 void ScriptEngine::notifyMediaUpdate (const Media::MediaSource::MediaInfo& media) {
@@ -682,17 +709,25 @@ void ScriptEngine::notifyMediaUpdate (const Media::MediaSource::MediaInfo& media
     JSValue mediaThumbnailArgs[] = { mediaThumbnailEvent };
 
     for (auto& module : this->m_scriptModules | std::views::values) {
-	// call all methods
-	JSValue result1 = this->call (module.module, 1, propertiesArgs, "mediaPropertiesChanged");
+		if (!module.initialized) {
+		    continue;
+		}
+
+		this->bindModule (module);
+
+		// call all methods
+		JSValue result1 = this->call (module.module, 1, propertiesArgs, "mediaPropertiesChanged");
 	JSValue result2 = this->call (module.module, 1, playbackArgs, "mediaPlaybackChanged");
 	JSValue result3 = this->call (module.module, 1, mediaTimelineArgs, "mediaTimelineChanged");
 	JSValue result4 = this->call (module.module, 1, mediaThumbnailArgs, "mediaThumbnailChanged");
 
 	JS_FreeValue (ctx, result1);
 	JS_FreeValue (ctx, result2);
-	JS_FreeValue (ctx, result3);
-	JS_FreeValue (ctx, result4);
+		JS_FreeValue (ctx, result3);
+		JS_FreeValue (ctx, result4);
     }
+
+    this->m_runningModule = nullptr;
 
     // free all created objects as we don't keep a ref to them anymore
     JS_FreeValue (ctx, propertiesEvent);

--- a/src/WallpaperEngine/Scripting/ScriptEngine.h
+++ b/src/WallpaperEngine/Scripting/ScriptEngine.h
@@ -33,6 +33,7 @@ class CScene;
 
 namespace WallpaperEngine::Scripting {
 class ScriptPropertiesObject;
+class ScriptableObject;
 namespace Adapters {
     class ScriptableObjectAdapter;
 }
@@ -45,8 +46,11 @@ static constexpr ScriptLayerHandle kInvalidLayerHandle = 0;
 class ScriptEngine {
 public:
     struct LoadedModule {
-	DynamicValue& value;
-	JSValue module;
+		DynamicValue& value;
+		ScriptableObject& object;
+		JSValue module;
+		JSValue thisLayer;
+		bool initialized = false;
     };
     struct JSObjectAdapters {
 	std::unique_ptr<Adapters::VectorAdapter<4>> vec4;
@@ -140,6 +144,7 @@ public:
 
 private:
     JSValue call (JSValue module, int argc, JSValueConst argv[], const char* name);
+    void bindModule (LoadedModule& module);
 
     void installBuiltins ();
 

--- a/src/WallpaperEngine/Scripting/ScriptableObject.cpp
+++ b/src/WallpaperEngine/Scripting/ScriptableObject.cpp
@@ -30,6 +30,21 @@ const std::map<std::string, ScriptableObject::PropertyEntry>& ScriptableObject::
     return this->m_properties;
 }
 
+std::vector<ScriptableObject*> ScriptableObject::getChildren () const {
+    std::vector<ScriptableObject*> children;
+
+    for (auto* object : this->getScene ().getObjectsByRenderOrder ()) {
+		const auto& parent = object->getObject ().parent;
+		if (!parent.has_value () || parent.value () != this->getId () || !object->is<ScriptableObject> ()) {
+		    continue;
+		}
+
+		children.push_back (object->as<ScriptableObject> ());
+    }
+
+    return children;
+}
+
 void ScriptableObject::registerProperty (const std::string& name, DynamicValue& value) {
     auto inserted = this->m_properties.emplace (
 	name, PropertyEntry { .key = name + "_" + std::to_string (this->getId ()), .value = value }

--- a/src/WallpaperEngine/Scripting/ScriptableObject.h
+++ b/src/WallpaperEngine/Scripting/ScriptableObject.h
@@ -2,6 +2,8 @@
 #include "WallpaperEngine/Data/Model/Types.h"
 #include "WallpaperEngine/Render/CObject.h"
 
+#include <vector>
+
 namespace WallpaperEngine::Render::Wallpapers {
 class CScene;
 }
@@ -20,6 +22,8 @@ public:
     DynamicValue& getProperty (const std::string& name);
 
     const std::map<std::string, PropertyEntry>& getProperties () const;
+
+    [[nodiscard]] std::vector<ScriptableObject*> getChildren () const;
 
 protected:
     void registerProperty (const std::string& name, DynamicValue& value);

--- a/src/WallpaperEngine/Testing/Cases/AudioPlaybackState.cpp
+++ b/src/WallpaperEngine/Testing/Cases/AudioPlaybackState.cpp
@@ -1,0 +1,50 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "WallpaperEngine/Audio/AudioPlaybackState.h"
+
+using WallpaperEngine::Audio::AudioPlaybackState;
+
+TEST_CASE ("Audio playback state preserves pause and rewinds after stop") {
+    AudioPlaybackState state;
+
+    CHECK (state.isPlaying ());
+
+    state.pause ();
+    CHECK_FALSE (state.isPlaying ());
+
+    state.play ();
+    CHECK (state.isPlaying ());
+
+    const auto generation = state.stop ();
+    CHECK_FALSE (state.isPlaying ());
+    CHECK (state.resetPending ());
+
+    state.play ();
+    CHECK_FALSE (state.isPlaying ());
+
+    state.markResetComplete (generation);
+    CHECK_FALSE (state.resetPending ());
+    CHECK (state.isPlaying ());
+}
+
+TEST_CASE ("Audio playback state ignores stale rewind completion and clamps volume") {
+    AudioPlaybackState state;
+
+    const auto staleGeneration = state.stop ();
+    const auto currentGeneration = state.stop ();
+    state.play ();
+
+    state.markResetComplete (staleGeneration);
+    CHECK (state.resetPending ());
+    CHECK_FALSE (state.isPlaying ());
+
+    state.markResetComplete (currentGeneration);
+    CHECK (state.isPlaying ());
+
+    state.setVolume (-0.5f);
+    CHECK (state.volume () == 0.0f);
+    state.setVolume (0.6f);
+    CHECK (state.volume () == 0.6f);
+    state.setVolume (1.5f);
+    CHECK (state.volume () == 1.0f);
+}


### PR DESCRIPTION
Fixes #448

Implementation summary

Fixed the SceneScript init lifecycle and per-module "thisLayer" binding, and implemented the layer "name"/"getChildren()" APIs along with the sound layer "play"/"pause"/"stop"/"isPlaying"/"volume" APIs. Audio is mixed using per-layer Playing/Paused/Stopped states: pause preserves the playback position, while play after stop safely resets the decoder, queue, and remaining SDL buffer so playback restarts from the beginning. Existing autoplay and loop behavior for sounds not using SceneScript is preserved.

Changes

CMakeLists.txt                                     |   1 +
src/WallpaperEngine/Audio/AudioPlaybackState.h     |  44 ++++
src/WallpaperEngine/Audio/AudioStream.cpp          | 256 +++++++++++++++++----
src/WallpaperEngine/Audio/AudioStream.h            |  31 ++-
.../Audio/Drivers/SDLAudioDriver.cpp               |  77 +++++--
src/WallpaperEngine/Audio/Drivers/SDLAudioDriver.h |   4 +-
src/WallpaperEngine/Render/Objects/CSound.cpp      |  42 +++-
src/WallpaperEngine/Render/Objects/CSound.h        |  11 +-
.../Scripting/Adapters/ScriptableObjectAdapter.cpp | 142 ++++++++++--
src/WallpaperEngine/Scripting/ScriptEngine.cpp     | 125 ++++++----
src/WallpaperEngine/Scripting/ScriptEngine.h       |   9 +-
src/WallpaperEngine/Scripting/ScriptableObject.cpp |  15 ++
src/WallpaperEngine/Scripting/ScriptableObject.h   |   6 +-
.../Testing/Cases/AudioPlaybackState.cpp           |  50 ++++
14 files changed, 673 insertions(+), 140 deletions(-)

Testing

- "rm -rf build/verify-src build/verify-build && mkdir -p build/verify-src build/verify-build && rsync -a --exclude build --exclude .git ./ build/verify-src/ && [build-only submodule symlink setup] && ln -s ../cef build/verify-build/cef" — passed: Linked the actual submodules from the same issue workspace and the already-downloaded CEF into a validation copy under "build/" without modifying the original source tree.
- "cmake -S build/verify-src -B build/verify-build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug" — passed: The Debug test configuration completed successfully and build files were generated. All required compilers and system development libraries were available.
- "cmake --build build/verify-build --target tests -j$(nproc)" — passed: The "tests" target linked successfully. The modified "AudioStream.cpp", "SDLAudioDriver.cpp", "CSound.cpp", "ScriptEngine.cpp", "ScriptableObjectAdapter.cpp", and "AudioPlaybackState.cpp" were all compiled. There were no errors other than existing FFmpeg deprecated API warnings.
- "./build/verify-build/output/tests" — passed: All Catch2 tests passed: 37 assertions in 11 test cases.
- "./build/verify-build/output/tests "Audio playback state*"" — passed: The focused audio playback state regression tests passed: 14 assertions in 2 test cases.
- "cmake --build build/verify-build --target linux-wallpaperengine -j$(nproc)" — passed: Both "linux-wallpaperengine-lib" and the final "linux-wallpaperengine" executable built and linked successfully.
- "for p in "$HOME/.local/share/Steam/steamapps/workshop/content/431960/3596485909" "$HOME/.steam/steam/steamapps/workshop/content/431960/3596485909"; do if [ -d "$p" ]; then echo "FOUND $p"; else echo "MISSING $p"; fi; done" — passed: Checked both standard Steam Workshop locations and confirmed that the "3596485909" asset is not installed.
- "./build/verify-build/output/linux-wallpaperengine --help" — passed: The final built executable loaded successfully, printed its usage information, and exited with status code 0.