### PR TITLE
feat: add --hwdec CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ If you're one of those developers, feel free to open an issue to get your projec
 | `--noautomute` | Don't mute when other apps play audio |
 | `--no-audio-processing` | Disable audio reactive features |
 | `--fps <val>` | Limit frame rate |
+| `--hwdec <mode>` | Set libmpv hardware decoding: `auto`, `nvdec-copy`, or `no` (default: `auto`) |
 | `--window <XxYxWxH>` | Run in windowed mode with custom size/position |
 | `--screen-root <screen>` | Set as background for specific screen |
 | `--screen-span <screen-1>,<screen-2>,...` | Stretch a single wallpaper across multiple screens |

--- a/src/WallpaperEngine/Application/ApplicationContext.cpp
+++ b/src/WallpaperEngine/Application/ApplicationContext.cpp
@@ -493,6 +493,11 @@ void ApplicationContext::loadSettingsFromArgv () {
 	.default_value (30)
 	.store_into (this->settings.render.maximumFPS);
 
+    performanceGroup.add_argument ("--hwdec")
+	.help ("Selects the libmpv hardware decoder (auto, nvdec-copy, or no). Default: auto")
+	.choices ("auto", "nvdec-copy", "no")
+	.store_into (this->settings.render.hwdec);
+
     performanceGroup.add_argument ("--no-fullscreen-pause")
 	.help ("Prevents the background pausing when an app is fullscreen")
 	.flag ()

--- a/src/WallpaperEngine/Application/ApplicationContext.h
+++ b/src/WallpaperEngine/Application/ApplicationContext.h
@@ -113,6 +113,8 @@ public:
 	    WINDOW_MODE mode;
 	    /** Maximum FPS */
 	    int maximumFPS;
+	    /** Hardware decoder passed to libmpv */
+	    std::string hwdec;
 	    /** Indicates if pausing should happen when something goes fullscreen */
 	    bool pauseOnFullscreen;
 	    /**
@@ -200,6 +202,7 @@ public:
         .render = {
             .mode = NORMAL_WINDOW,
             .maximumFPS = 30,
+            .hwdec = "auto",
             .pauseOnFullscreen = true,
             .pauseOnFullscreenOnlyWhenActive = false,
             .fullscreenPauseIgnoreAppIds = {},

--- a/src/WallpaperEngine/VideoPlayback/MPV/GLPlayer.cpp
+++ b/src/WallpaperEngine/VideoPlayback/MPV/GLPlayer.cpp
@@ -228,7 +228,8 @@ void GLPlayer::init () {
     }
 
     // ensure video is muted and plays in a loop
-    mpv_set_property_string (this->m_handle, "hwdec", "auto");
+    const auto& hwdec = this->getContext ().getApp ().getContext ().settings.render.hwdec;
+    mpv_set_property_string (this->m_handle, "hwdec", hwdec.c_str ());
     mpv_set_property_string (this->m_handle, "loop", "inf");
     mpv_set_property (this->m_handle, "volume", MPV_FORMAT_DOUBLE, &this->m_volume);
 


### PR DESCRIPTION
## Summary

- add a `--hwdec {auto,nvdec-copy,no}` command-line option
- keep `auto` as the default so existing behavior is unchanged
- pass the selected mode to every libmpv-backed `GLPlayer`
- document the new option in the README

## Motivation

`GLPlayer` currently hard-codes `hwdec=auto`, so users and frontend integrations cannot choose a predictable decoding path. On NVIDIA systems, callers may need `nvdec-copy` to avoid unsuitable automatic decoder selection, while `no` provides an explicit software-decoding fallback. The default remains `auto`.

This is a focused partial implementation of #243; it does not expose arbitrary mpv options or device selectors.

## Test plan

- [x] Release build succeeds
- [x] existing unit tests pass (9 test cases, 23 assertions)
- [x] clang-format check passes
- [x] `--help` lists `--hwdec`
- [x] `auto`, `nvdec-copy`, and `no` are accepted
- [x] omitted option retains the default
- [x] unsupported and missing values are rejected
- [x] `nvdec-copy` verified on an NVIDIA system

Related to #243
